### PR TITLE
Added in support for getting player summaries for multiple users at once

### DIFF
--- a/SteamWebAPI2/Interfaces/ISteamUser.cs
+++ b/SteamWebAPI2/Interfaces/ISteamUser.cs
@@ -1,5 +1,4 @@
 ﻿using Steam.Models.SteamCommunity;
-using SteamWebAPI2.Models.SteamCommunity;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -14,6 +13,8 @@ namespace SteamWebAPI2.Interfaces
         Task<IReadOnlyCollection<PlayerBansModel>> GetPlayerBansAsync(IReadOnlyCollection<long> steamIds);
 
         Task<PlayerSummaryModel> GetPlayerSummaryAsync(long steamId);
+
+        Task<List<PlayerSummaryModel>> GetPlayerSummariesAsync(List<long> steamIds);
 
         Task<IReadOnlyCollection<long>> GetUserGroupsAsync(long steamId);
 

--- a/SteamWebAPI2/Interfaces/SteamUser.cs
+++ b/SteamWebAPI2/Interfaces/SteamUser.cs
@@ -38,6 +38,20 @@ namespace SteamWebAPI2.Interfaces
             }
         }
 
+        public async Task<List<PlayerSummaryModel>> GetPlayerSummariesAsync(List<long> steamIds)
+        {
+            // convert steam ids to a csv for the api
+            var steamIdsCsv = string.Join(",", steamIds.Select(x => x.ToString()).ToArray());
+            var parameters = new List<SteamWebRequestParameter>();
+            parameters.AddIfHasValue(steamIdsCsv, "steamids");
+
+            var playerSummaries = await CallMethodAsync<PlayerSummaryResultContainer>("GetPlayerSummaries", 2, parameters);
+            if (playerSummaries.Result.Players != null && playerSummaries.Result.Players.Count > 0)
+                return playerSummaries.Result.Players.Select(player => AutoMapperConfiguration.Mapper.Map<PlayerSummary, PlayerSummaryModel>(player)).ToList();
+
+            return null;
+        }
+
         public async Task<IReadOnlyCollection<FriendModel>> GetFriendsListAsync(long steamId, string relationship = "")
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();


### PR DESCRIPTION
The Steam Web API supports getting player summaries for multiple users at once by supplying 64-bit ids in a comma-separated format. The results are then returned as an array for each player.

I've created a new method to enable passing in of a list of 64-bit ids and getting back a list of player summaries. I've tested this to work.