### PR TITLE
Bug fix for wrong mapping in SteamStore.cs - GetStoreAppDetailsAsync.

### DIFF
--- a/SteamWebAPI2/Interfaces/SteamStore.cs
+++ b/SteamWebAPI2/Interfaces/SteamStore.cs
@@ -22,9 +22,11 @@ namespace SteamWebAPI2.Interfaces
 
             parameters.AddIfHasValue(appId, "appids");
 
-            var appDetails = await CallMethodAsync<AppDetailsContainer>("appdetails", parameters);
+			// Edit by Jir : Was mapping to AppDetailsContainer previously; correct one should be Data instead.			 
+			var appDetails = await CallMethodAsync<Data>("appdetails", parameters);
 
-            var appDetailsModel = AutoMapperConfiguration.Mapper.Map<Data, StoreAppDetailsDataModel>(appDetails.Data);
+            var appDetailsModel = AutoMapperConfiguration.Mapper.Map<Data, StoreAppDetailsDataModel>(appDetails);
+
 
             return appDetailsModel;
         }


### PR DESCRIPTION
A quick bug fix; the data type in GetStoreAppDetailsAsync was wrongly mapped; changed to correct one now.