### PR TITLE
Fixed StoreAppDetailsContainerJsonConverter to return the correct exp…

### DIFF
--- a/SteamWebAPI2/Utilities/JsonConverters/StoreAppDetailsContainerJsonConverter.cs
+++ b/SteamWebAPI2/Utilities/JsonConverters/StoreAppDetailsContainerJsonConverter.cs
@@ -31,8 +31,13 @@ namespace SteamWebAPI2.Utilities.JsonConverters
 
             foreach (var x in o)
             {
+				// Edit by Jir : Previously returning Data; should return the correct object AppDetailsContainer instead. Sorry for ugly code
                 var data = x.Value["data"].ToObject<Data>();
-                return data;
+                var success = x.Value["success"].ToObject<bool>();
+                AppDetailsContainer appDetailsContainer = new AppDetailsContainer{ Data = data, Success = success };
+                return appDetailsContainer;
+				
+				// return data; 
             }
 
             return null;


### PR DESCRIPTION
Expecting AppDetailsContainer object, but was returning Data object instead.

Causes the GetStoreAppDetailsAsync function to fail...

I've wrapped it (albeit in pretty ghetto code) to return the correct object now.