### PR TITLE
Issue 36 http response headers

### DIFF
--- a/SteamWebAPI2.Net451/Properties/AssemblyInfo.cs
+++ b/SteamWebAPI2.Net451/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyVersion("3.1.0.0")]
 [assembly: AssemblyFileVersion("3.0.0.0")]

--- a/SteamWebAPI2.Net451/SteamWebAPI2.Net451.csproj
+++ b/SteamWebAPI2.Net451/SteamWebAPI2.Net451.csproj
@@ -39,8 +39,8 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Steam.Models, Version=2.0.0.2, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Steam.Models.2.0.0.2\lib\net451\Steam.Models.dll</HintPath>
+    <Reference Include="Steam.Models, Version=2.0.0.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Steam.Models.2.0.0.3\lib\net451\Steam.Models.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/SteamWebAPI2.Net451/SteamWebAPI2.Net451.csproj
+++ b/SteamWebAPI2.Net451/SteamWebAPI2.Net451.csproj
@@ -378,6 +378,9 @@
     <Compile Include="..\SteamWebAPI2\Utilities\ISteamWebRequest.cs">
       <Link>Utilities\ISteamWebRequest.cs</Link>
     </Compile>
+    <Compile Include="..\SteamWebAPI2\Utilities\ISteamWebResponse.cs">
+      <Link>Utilities\ISteamWebResponse.cs</Link>
+    </Compile>
     <Compile Include="..\SteamWebAPI2\Utilities\JsonConverters\AssetClassInfoJsonConverter.cs">
       <Link>Utilities\JsonConverters\AssetClassInfoJsonConverter.cs</Link>
     </Compile>
@@ -410,6 +413,9 @@
     </Compile>
     <Compile Include="..\SteamWebAPI2\Utilities\SteamWebRequestParameterExtensions.cs">
       <Link>Utilities\SteamWebRequestParameterExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\SteamWebAPI2\Utilities\SteamWebResponse.cs">
+      <Link>Utilities\SteamWebResponse.cs</Link>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/SteamWebAPI2.Net451/SteamWebAPI2.Net451.csproj
+++ b/SteamWebAPI2.Net451/SteamWebAPI2.Net451.csproj
@@ -31,8 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AutoMapper, Version=4.2.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoMapper.4.2.1\lib\net45\AutoMapper.dll</HintPath>
+    <Reference Include="AutoMapper, Version=5.2.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.5.2.0\lib\net45\AutoMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/SteamWebAPI2.Net451/packages.config
+++ b/SteamWebAPI2.Net451/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="AutoMapper" version="4.2.1" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
-  <package id="Steam.Models" version="2.0.0.2" targetFramework="net451" />
+  <package id="Steam.Models" version="2.0.0.3" targetFramework="net451" />
 </packages>

--- a/SteamWebAPI2.Net451/packages.config
+++ b/SteamWebAPI2.Net451/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoMapper" version="4.2.1" targetFramework="net451" />
+  <package id="AutoMapper" version="5.2.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="Steam.Models" version="2.0.0.3" targetFramework="net451" />
 </packages>

--- a/SteamWebAPI2.Net452/Properties/AssemblyInfo.cs
+++ b/SteamWebAPI2.Net452/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyVersion("3.1.0.0")]
 [assembly: AssemblyFileVersion("3.0.0.0")]

--- a/SteamWebAPI2.Net452/SteamWebAPI2.Net452.csproj
+++ b/SteamWebAPI2.Net452/SteamWebAPI2.Net452.csproj
@@ -379,6 +379,9 @@
     <Compile Include="..\SteamWebAPI2\Utilities\ISteamWebRequest.cs">
       <Link>Utilities\ISteamWebRequest.cs</Link>
     </Compile>
+    <Compile Include="..\SteamWebAPI2\Utilities\ISteamWebResponse.cs">
+      <Link>Utilities\ISteamWebResponse.cs</Link>
+    </Compile>
     <Compile Include="..\SteamWebAPI2\Utilities\JsonConverters\AssetClassInfoJsonConverter.cs">
       <Link>Utilities\JsonConverters\AssetClassInfoJsonConverter.cs</Link>
     </Compile>
@@ -411,6 +414,9 @@
     </Compile>
     <Compile Include="..\SteamWebAPI2\Utilities\SteamWebRequestParameterExtensions.cs">
       <Link>Utilities\SteamWebRequestParameterExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\SteamWebAPI2\Utilities\SteamWebResponse.cs">
+      <Link>Utilities\SteamWebResponse.cs</Link>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/SteamWebAPI2.Net452/SteamWebAPI2.Net452.csproj
+++ b/SteamWebAPI2.Net452/SteamWebAPI2.Net452.csproj
@@ -31,8 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AutoMapper, Version=4.2.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoMapper.4.2.1\lib\net45\AutoMapper.dll</HintPath>
+    <Reference Include="AutoMapper, Version=5.2.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.5.2.0\lib\net45\AutoMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/SteamWebAPI2.Net452/SteamWebAPI2.Net452.csproj
+++ b/SteamWebAPI2.Net452/SteamWebAPI2.Net452.csproj
@@ -39,8 +39,8 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Steam.Models, Version=2.0.0.2, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Steam.Models.2.0.0.2\lib\net452\Steam.Models.dll</HintPath>
+    <Reference Include="Steam.Models, Version=2.0.0.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Steam.Models.2.0.0.3\lib\net452\Steam.Models.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/SteamWebAPI2.Net452/packages.config
+++ b/SteamWebAPI2.Net452/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoMapper" version="4.2.1" targetFramework="net452" />
+  <package id="AutoMapper" version="5.2.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="Steam.Models" version="2.0.0.3" targetFramework="net452" />
 </packages>

--- a/SteamWebAPI2.Net452/packages.config
+++ b/SteamWebAPI2.Net452/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="AutoMapper" version="4.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="Steam.Models" version="2.0.0.2" targetFramework="net452" />
+  <package id="Steam.Models" version="2.0.0.3" targetFramework="net452" />
 </packages>

--- a/SteamWebAPI2.Tests/PlayerServiceTests.cs
+++ b/SteamWebAPI2.Tests/PlayerServiceTests.cs
@@ -32,12 +32,12 @@ namespace SteamWebAPI2.Tests
             var mockSteamWebRequest = new Mock<ISteamWebInterface>();
 
             mockSteamWebRequest.Setup(x => x.GetAsync<PlayingSharedGameResultContainer>(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IList<SteamWebRequestParameter>>()))
-                .ReturnsAsync((PlayingSharedGameResultContainer)null);
+                .ReturnsAsync((ISteamWebResponse<PlayingSharedGameResultContainer>)null);
 
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);
             var result = await service.IsPlayingSharedGameAsync(It.IsAny<ulong>(), It.IsAny<uint>());
 
-            Assert.IsTrue(!result.HasValue);
+            Assert.IsTrue(!result.Data.HasValue);
         }
 
         [TestMethod]
@@ -46,15 +46,18 @@ namespace SteamWebAPI2.Tests
             var mockSteamWebRequest = new Mock<ISteamWebInterface>();
 
             mockSteamWebRequest.Setup(x => x.GetAsync<PlayingSharedGameResultContainer>(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IList<SteamWebRequestParameter>>()))
-                .ReturnsAsync(new PlayingSharedGameResultContainer()
+                .ReturnsAsync(new SteamWebResponse<PlayingSharedGameResultContainer>()
                 {
-                    Result = null
+                    Data = new PlayingSharedGameResultContainer()
+                    {
+                        Result = null
+                    }
                 });
 
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);
             var result = await service.IsPlayingSharedGameAsync(It.IsAny<ulong>(), It.IsAny<uint>());
 
-            Assert.IsTrue(!result.HasValue);
+            Assert.IsTrue(!result.Data.HasValue);
         }
 
         [TestMethod]
@@ -63,12 +66,12 @@ namespace SteamWebAPI2.Tests
             var mockSteamWebRequest = new Mock<ISteamWebInterface>();
 
             mockSteamWebRequest.Setup(x => x.GetAsync<BadgesResultContainer>(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IList<SteamWebRequestParameter>>()))
-                .ReturnsAsync((BadgesResultContainer)null);
+                .ReturnsAsync((ISteamWebResponse<BadgesResultContainer>)null);
 
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);
             var result = await service.GetBadgesAsync(It.IsAny<ulong>());
 
-            Assert.IsNull(result);
+            Assert.IsNull(result.Data);
         }
 
         [TestMethod]
@@ -77,9 +80,12 @@ namespace SteamWebAPI2.Tests
             var mockSteamWebRequest = new Mock<ISteamWebInterface>();
 
             mockSteamWebRequest.Setup(x => x.GetAsync<BadgesResultContainer>(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IList<SteamWebRequestParameter>>()))
-                .ReturnsAsync(new BadgesResultContainer()
+                .ReturnsAsync(new SteamWebResponse<BadgesResultContainer>()
                 {
-                    Result = null
+                    Data = new BadgesResultContainer()
+                    {
+                        Result = null
+                    }
                 });
 
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);
@@ -94,12 +100,12 @@ namespace SteamWebAPI2.Tests
             var mockSteamWebRequest = new Mock<ISteamWebInterface>();
 
             mockSteamWebRequest.Setup(x => x.GetAsync<CommunityBadgeProgressResultContainer>(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IList<SteamWebRequestParameter>>()))
-                .ReturnsAsync((CommunityBadgeProgressResultContainer)null);
+                .ReturnsAsync((ISteamWebResponse<CommunityBadgeProgressResultContainer>)null);
 
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);
             var result = await service.GetCommunityBadgeProgressAsync(It.IsAny<uint>(), It.IsAny<uint?>());
 
-            Assert.IsNull(result);
+            Assert.IsNull(result.Data);
         }
 
         [TestMethod]
@@ -108,9 +114,12 @@ namespace SteamWebAPI2.Tests
             var mockSteamWebRequest = new Mock<ISteamWebInterface>();
 
             mockSteamWebRequest.Setup(x => x.GetAsync<CommunityBadgeProgressResultContainer>(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IList<SteamWebRequestParameter>>()))
-                .ReturnsAsync(new CommunityBadgeProgressResultContainer()
+                .ReturnsAsync(new SteamWebResponse<CommunityBadgeProgressResultContainer>()
                 {
-                    Result = null
+                    Data = new CommunityBadgeProgressResultContainer()
+                    {
+                        Result = null
+                    }
                 });
 
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);
@@ -125,12 +134,12 @@ namespace SteamWebAPI2.Tests
             var mockSteamWebRequest = new Mock<ISteamWebInterface>();
 
             mockSteamWebRequest.Setup(x => x.GetAsync<SteamLevelResultContainer>(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IList<SteamWebRequestParameter>>()))
-                .ReturnsAsync((SteamLevelResultContainer)null);
+                .ReturnsAsync((ISteamWebResponse<SteamLevelResultContainer>)null);
 
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);
             var result = await service.GetSteamLevelAsync(It.IsAny<uint>());
 
-            Assert.IsNull(result);
+            Assert.IsNull(result.Data);
         }
 
         [TestMethod]
@@ -139,9 +148,12 @@ namespace SteamWebAPI2.Tests
             var mockSteamWebRequest = new Mock<ISteamWebInterface>();
 
             mockSteamWebRequest.Setup(x => x.GetAsync<SteamLevelResultContainer>(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IList<SteamWebRequestParameter>>()))
-                .ReturnsAsync(new SteamLevelResultContainer()
+                .ReturnsAsync(new SteamWebResponse<SteamLevelResultContainer>()
                 {
-                    Result = null
+                    Data = new SteamLevelResultContainer()
+                    {
+                        Result = null
+                    }
                 });
 
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);
@@ -156,12 +168,12 @@ namespace SteamWebAPI2.Tests
             var mockSteamWebRequest = new Mock<ISteamWebInterface>();
 
             mockSteamWebRequest.Setup(x => x.GetAsync<OwnedGamesResultContainer>(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IList<SteamWebRequestParameter>>()))
-                .ReturnsAsync((OwnedGamesResultContainer)null);
+                .ReturnsAsync((ISteamWebResponse<OwnedGamesResultContainer>)null);
 
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);
             var result = await service.GetOwnedGamesAsync(It.IsAny<ulong>(), It.IsAny<bool?>(), It.IsAny<bool?>(), It.IsAny<IReadOnlyCollection<uint>>());
 
-            Assert.IsNull(result);
+            Assert.IsNull(result.Data);
         }
 
         [TestMethod]
@@ -170,9 +182,12 @@ namespace SteamWebAPI2.Tests
             var mockSteamWebRequest = new Mock<ISteamWebInterface>();
 
             mockSteamWebRequest.Setup(x => x.GetAsync<OwnedGamesResultContainer>(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IList<SteamWebRequestParameter>>()))
-                .ReturnsAsync(new OwnedGamesResultContainer()
+                .ReturnsAsync(new SteamWebResponse<OwnedGamesResultContainer>()
                 {
-                    Result = null
+                    Data = new OwnedGamesResultContainer()
+                    {
+                        Result = null
+                    }
                 });
 
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);
@@ -187,18 +202,21 @@ namespace SteamWebAPI2.Tests
             var mockSteamWebRequest = new Mock<ISteamWebInterface>();
 
             mockSteamWebRequest.Setup(x => x.GetAsync<OwnedGamesResultContainer>(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IList<SteamWebRequestParameter>>()))
-                .ReturnsAsync(new OwnedGamesResultContainer()
+                .ReturnsAsync(new SteamWebResponse<OwnedGamesResultContainer>()
                 {
-                    Result = new OwnedGamesResult()
+                    Data = new OwnedGamesResultContainer()
                     {
-                        GameCount = 10,
-                        OwnedGames = new List<OwnedGame>()
+                        Result = new OwnedGamesResult()
+                        {
+                            GameCount = 10,
+                            OwnedGames = new List<OwnedGame>()
                         {
                             new OwnedGame() { Name = "   Test Game 1  " },
                             new OwnedGame() { Name = "   Test Game 2  " },
                             new OwnedGame() { Name = "   Test Game 3  " },
                             new OwnedGame() { Name = "   Test Game 4  " },
                             new OwnedGame() { Name = "   Test Game 5  " },
+                        }
                         }
                     }
                 });
@@ -207,7 +225,7 @@ namespace SteamWebAPI2.Tests
             var result = await service.GetOwnedGamesAsync(It.IsAny<ulong>(), It.IsAny<bool?>(), It.IsAny<bool?>(), It.IsAny<IReadOnlyCollection<uint>>());
 
             // Make sure all game names have been trimmed on the edges
-            foreach(var game in result.OwnedGames)
+            foreach (var game in result.Data.OwnedGames)
             {
                 Assert.IsTrue(!game.Name.StartsWith(" "));
                 Assert.IsTrue(!game.Name.EndsWith(" "));
@@ -220,12 +238,12 @@ namespace SteamWebAPI2.Tests
             var mockSteamWebRequest = new Mock<ISteamWebInterface>();
 
             mockSteamWebRequest.Setup(x => x.GetAsync<RecentlyPlayedGameResultContainer>(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IList<SteamWebRequestParameter>>()))
-                .ReturnsAsync((RecentlyPlayedGameResultContainer)null);
+                .ReturnsAsync((ISteamWebResponse<RecentlyPlayedGameResultContainer>)null);
 
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);
             var result = await service.GetRecentlyPlayedGamesAsync(It.IsAny<ulong>());
 
-            Assert.IsNull(result);
+            Assert.IsNull(result.Data);
         }
 
         [TestMethod]
@@ -234,9 +252,12 @@ namespace SteamWebAPI2.Tests
             var mockSteamWebRequest = new Mock<ISteamWebInterface>();
 
             mockSteamWebRequest.Setup(x => x.GetAsync<RecentlyPlayedGameResultContainer>(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IList<SteamWebRequestParameter>>()))
-                .ReturnsAsync(new RecentlyPlayedGameResultContainer()
+                .ReturnsAsync(new SteamWebResponse<RecentlyPlayedGameResultContainer>()
                 {
-                    Result = null
+                    Data = new RecentlyPlayedGameResultContainer()
+                    {
+                        Result = null
+                    }
                 });
 
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);

--- a/SteamWebAPI2.Tests/PlayerServiceTests.cs
+++ b/SteamWebAPI2.Tests/PlayerServiceTests.cs
@@ -37,11 +37,11 @@ namespace SteamWebAPI2.Tests
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);
             var result = await service.IsPlayingSharedGameAsync(It.IsAny<ulong>(), It.IsAny<uint>());
 
-            Assert.IsTrue(!result.Data.HasValue);
+            Assert.IsNull(result);
         }
 
         [TestMethod]
-        public async Task PlayerService_IsPlayingSharedGameAsync_Return_Null_If_Web_Interface_Result_Is_Null()
+        public async Task PlayerService_IsPlayingSharedGameAsync_Return_Null_Data_If_Web_Interface_Result_Is_Null()
         {
             var mockSteamWebRequest = new Mock<ISteamWebInterface>();
 
@@ -57,7 +57,7 @@ namespace SteamWebAPI2.Tests
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);
             var result = await service.IsPlayingSharedGameAsync(It.IsAny<ulong>(), It.IsAny<uint>());
 
-            Assert.IsTrue(!result.Data.HasValue);
+            Assert.IsNull(result.Data);
         }
 
         [TestMethod]
@@ -71,11 +71,11 @@ namespace SteamWebAPI2.Tests
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);
             var result = await service.GetBadgesAsync(It.IsAny<ulong>());
 
-            Assert.IsNull(result.Data);
+            Assert.IsNull(result);
         }
 
         [TestMethod]
-        public async Task PlayerService_GetBadgesAsync_Return_Null_If_Web_Interface_Result_Is_Null()
+        public async Task PlayerService_GetBadgesAsync_Return_Null_Data_If_Web_Interface_Result_Is_Null()
         {
             var mockSteamWebRequest = new Mock<ISteamWebInterface>();
 
@@ -91,7 +91,7 @@ namespace SteamWebAPI2.Tests
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);
             var result = await service.GetBadgesAsync(It.IsAny<ulong>());
 
-            Assert.IsNull(result);
+            Assert.IsNull(result.Data);
         }
 
         [TestMethod]
@@ -105,11 +105,11 @@ namespace SteamWebAPI2.Tests
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);
             var result = await service.GetCommunityBadgeProgressAsync(It.IsAny<uint>(), It.IsAny<uint?>());
 
-            Assert.IsNull(result.Data);
+            Assert.IsNull(result);
         }
 
         [TestMethod]
-        public async Task PlayerService_GetCommunityBadgeProgressAsync_Return_Null_If_Web_Interface_Result_Is_Null()
+        public async Task PlayerService_GetCommunityBadgeProgressAsync_Return_Empty_Data_If_Web_Interface_Result_Is_Null()
         {
             var mockSteamWebRequest = new Mock<ISteamWebInterface>();
 
@@ -125,7 +125,7 @@ namespace SteamWebAPI2.Tests
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);
             var result = await service.GetCommunityBadgeProgressAsync(It.IsAny<uint>(), It.IsAny<uint?>());
 
-            Assert.IsNull(result);
+            Assert.IsTrue(result.Data.Count == 0);
         }
 
         [TestMethod]
@@ -139,11 +139,11 @@ namespace SteamWebAPI2.Tests
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);
             var result = await service.GetSteamLevelAsync(It.IsAny<uint>());
 
-            Assert.IsNull(result.Data);
+            Assert.IsNull(result);
         }
 
         [TestMethod]
-        public async Task PlayerService_GetSteamLevelAsync_Return_Null_If_Web_Interface_Result_Is_Null()
+        public async Task PlayerService_GetSteamLevelAsync_Return_Default_Data_If_Web_Interface_Result_Is_Null()
         {
             var mockSteamWebRequest = new Mock<ISteamWebInterface>();
 
@@ -157,9 +157,9 @@ namespace SteamWebAPI2.Tests
                 });
 
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);
-            var result = await service.GetSteamLevelAsync(It.IsAny<uint>());
+            var result = await service.GetSteamLevelAsync(It.IsAny<ulong>());
 
-            Assert.IsNull(result);
+            Assert.IsNull(result.Data);
         }
 
         [TestMethod]
@@ -173,11 +173,11 @@ namespace SteamWebAPI2.Tests
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);
             var result = await service.GetOwnedGamesAsync(It.IsAny<ulong>(), It.IsAny<bool?>(), It.IsAny<bool?>(), It.IsAny<IReadOnlyCollection<uint>>());
 
-            Assert.IsNull(result.Data);
+            Assert.IsNull(result);
         }
 
         [TestMethod]
-        public async Task PlayerService_GetOwnedGamesAsync_Return_Null_If_Web_Interface_Result_Is_Null()
+        public async Task PlayerService_GetOwnedGamesAsync_Return_Null_Data_If_Web_Interface_Result_Is_Null()
         {
             var mockSteamWebRequest = new Mock<ISteamWebInterface>();
 
@@ -193,7 +193,7 @@ namespace SteamWebAPI2.Tests
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);
             var result = await service.GetOwnedGamesAsync(It.IsAny<ulong>(), It.IsAny<bool?>(), It.IsAny<bool?>(), It.IsAny<IReadOnlyCollection<uint>>());
 
-            Assert.IsNull(result);
+            Assert.IsNull(result.Data);
         }
 
         [TestMethod]
@@ -243,11 +243,11 @@ namespace SteamWebAPI2.Tests
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);
             var result = await service.GetRecentlyPlayedGamesAsync(It.IsAny<ulong>());
 
-            Assert.IsNull(result.Data);
+            Assert.IsNull(result);
         }
 
         [TestMethod]
-        public async Task PlayerService_GetRecentlyPlayedGamesAsync_Return_Null_If_Web_Interface_Result_Is_Null()
+        public async Task PlayerService_GetRecentlyPlayedGamesAsync_Return_Null_Data_If_Web_Interface_Result_Is_Null()
         {
             var mockSteamWebRequest = new Mock<ISteamWebInterface>();
 
@@ -263,7 +263,7 @@ namespace SteamWebAPI2.Tests
             var service = new PlayerService(String.Empty, mockSteamWebRequest.Object);
             var result = await service.GetRecentlyPlayedGamesAsync(It.IsAny<ulong>());
 
-            Assert.IsNull(result);
+            Assert.IsNull(result.Data);
         }
     }
 }

--- a/SteamWebAPI2.Tests/SteamWebAPI2.Tests.csproj
+++ b/SteamWebAPI2.Tests/SteamWebAPI2.Tests.csproj
@@ -36,8 +36,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Moq, Version=4.5.30.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
@@ -76,6 +76,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Choose>

--- a/SteamWebAPI2.Tests/SteamWebAPI2.Tests.csproj
+++ b/SteamWebAPI2.Tests/SteamWebAPI2.Tests.csproj
@@ -44,8 +44,8 @@
       <HintPath>..\packages\Moq.4.5.30\lib\net45\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Steam.Models, Version=2.0.0.2, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Steam.Models.2.0.0.2\lib\net46\Steam.Models.dll</HintPath>
+    <Reference Include="Steam.Models, Version=2.0.0.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Steam.Models.2.0.0.3\lib\net46\Steam.Models.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/SteamWebAPI2.Tests/app.config
+++ b/SteamWebAPI2.Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/SteamWebAPI2.Tests/packages.config
+++ b/SteamWebAPI2.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.3.3" targetFramework="net461" />
+  <package id="Castle.Core" version="4.0.0" targetFramework="net461" />
   <package id="Moq" version="4.5.30" targetFramework="net461" />
   <package id="Steam.Models" version="2.0.0.3" targetFramework="net461" />
 </packages>

--- a/SteamWebAPI2.Tests/packages.config
+++ b/SteamWebAPI2.Tests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net461" />
   <package id="Moq" version="4.5.30" targetFramework="net461" />
-  <package id="Steam.Models" version="2.0.0.2" targetFramework="net461" />
+  <package id="Steam.Models" version="2.0.0.3" targetFramework="net461" />
 </packages>

--- a/SteamWebAPI2/AutoMapperConfiguration.cs
+++ b/SteamWebAPI2/AutoMapperConfiguration.cs
@@ -27,6 +27,7 @@ namespace SteamWebAPI2
 {
     internal static class AutoMapperConfiguration
     {
+        private static bool isInitialized = false;
         private static MapperConfiguration config;
         private static IMapper mapper;
 
@@ -52,6 +53,11 @@ namespace SteamWebAPI2
 
         public static void Initialize()
         {
+            if(isInitialized)
+            {
+                return;
+            }
+
             if (config == null)
             {
                 config = new MapperConfiguration(x =>
@@ -63,18 +69,19 @@ namespace SteamWebAPI2
                     CreateSteamWebResponseMap<RarityResultContainer, IReadOnlyCollection<RarityModel>>(x);
                     CreateSteamWebResponseMap<PrizePoolResultContainer, uint>(x);
                     CreateSteamWebResponseMap<PlayerOfficialInfoResultContainer, PlayerOfficialInfoModel>(x);
-                    CreateSteamWebResponseMap<ProPlayerListResultContainer, ProPlayerDetailModel>(x);
+                    CreateSteamWebResponseMap<ProPlayerListResult, ProPlayerDetailModel>(x);
                     CreateSteamWebResponseMap<LeagueResultContainer, IReadOnlyCollection<LeagueModel>>(x);
                     CreateSteamWebResponseMap<LiveLeagueGameResultContainer, IReadOnlyCollection<LiveLeagueGameModel>>(x);
                     CreateSteamWebResponseMap<MatchDetailResultContainer, MatchDetailModel>(x);
                     CreateSteamWebResponseMap<MatchHistoryResultContainer, MatchHistoryModel>(x);
                     CreateSteamWebResponseMap<MatchHistoryBySequenceNumberResultContainer, IReadOnlyCollection<MatchHistoryMatchModel>>(x);
                     CreateSteamWebResponseMap<TeamInfoResultContainer, IReadOnlyCollection<TeamInfoModel>>(x);
-                    CreateSteamWebResponseMap<EconItemResultContainer, IReadOnlyCollection<EconItemResultModel>>(x);
-                    CreateSteamWebResponseMap<SchemaResultContainer, IReadOnlyCollection<Steam.Models.DOTA2.SchemaModel>>(x);
-                    CreateSteamWebResponseMap<SchemaUrlResultContainer, IReadOnlyCollection<string>>(x);
-                    CreateSteamWebResponseMap<StoreMetaDataResultContainer, IReadOnlyCollection<StoreMetaDataModel>>(x);
-                    CreateSteamWebResponseMap<StoreStatusResultContainer, IReadOnlyCollection<uint>>(x);
+                    CreateSteamWebResponseMap<EconItemResultContainer, EconItemResultModel>(x);
+                    CreateSteamWebResponseMap<SchemaResultContainer, Steam.Models.DOTA2.SchemaModel>(x);
+                    CreateSteamWebResponseMap<SchemaResultContainer, Steam.Models.TF2.SchemaModel>(x);
+                    CreateSteamWebResponseMap<SchemaUrlResultContainer, string>(x);
+                    CreateSteamWebResponseMap<StoreMetaDataResultContainer, StoreMetaDataModel>(x);
+                    CreateSteamWebResponseMap<StoreStatusResultContainer, uint>(x);
                     CreateSteamWebResponseMap<TradeHistoryResultContainer, Steam.Models.SteamEconomy.TradeHistoryModel>(x);
                     CreateSteamWebResponseMap<TradeOffersResultContainer, Steam.Models.SteamEconomy.TradeOffersResultModel>(x);
                     CreateSteamWebResponseMap<TradeOfferResultContainer, Steam.Models.SteamEconomy.TradeOfferResultModel>(x);
@@ -83,7 +90,7 @@ namespace SteamWebAPI2
                     CreateSteamWebResponseMap<CommunityBadgeProgressResultContainer, IReadOnlyCollection<BadgeQuestModel>>(x);
                     CreateSteamWebResponseMap<BadgesResultContainer, BadgesResultModel>(x);
                     CreateSteamWebResponseMap<SteamLevelResultContainer, uint?>(x);
-                    CreateSteamWebResponseMap<OwnedGamesResultContainer, OwnedGamesResultContainer>(x);
+                    CreateSteamWebResponseMap<OwnedGamesResultContainer, OwnedGamesResultModel>(x);
                     CreateSteamWebResponseMap<RecentlyPlayedGameResultContainer, RecentlyPlayedGamesResultModel>(x);
                     CreateSteamWebResponseMap<SteamAppListResultContainer, IReadOnlyCollection<SteamAppModel>>(x);
                     CreateSteamWebResponseMap<SteamAppUpToDateCheckResultContainer, SteamAppUpToDateCheckModel>(x);
@@ -162,16 +169,14 @@ namespace SteamWebAPI2
                     );
 
                     x.CreateMap<ProPlayerInfo, ProPlayerInfoModel>();
-                    x.CreateMap<ProPlayerLeaderboardModel, ProPlayerLeaderboard>();
+                    x.CreateMap<ProPlayerLeaderboard, ProPlayerLeaderboardModel>();
                     x.CreateMap<ProPlayerListResult, ProPlayerDetailModel>();
-                    x.CreateMap<ProPlayerListResultContainer, ProPlayerDetailModel>().ConstructUsing(
-                        src => Mapper.Map<ProPlayerListResult, ProPlayerDetailModel>(src.Result)
-                    );
 
                     #endregion
 
                     #region Endpoint: DOTA2Match
 
+                    x.CreateMap<League, LeagueModel>();
                     x.CreateMap<LeagueResultContainer, IReadOnlyCollection<LeagueModel>>().ConstructUsing(
                         src => Mapper.Map<IList<League>, IReadOnlyCollection<LeagueModel>>(src.Result.Leagues)
                     );
@@ -191,7 +196,8 @@ namespace SteamWebAPI2
                         src => Mapper.Map<IList<LiveLeagueGame>, IReadOnlyCollection<LiveLeagueGameModel>>(src.Result.Games)
                     );
 
-                    x.CreateMap<MatchDetailResult, MatchDetailModel>();
+                    x.CreateMap<MatchDetailResult, MatchDetailModel>()
+                        .ForMember(dest => dest.StartTime, opts => opts.MapFrom(src => src.StartTime.ToDateTime()));
                     x.CreateMap<MatchPlayer, MatchPlayerModel>();
                     x.CreateMap<MatchPlayerAbilityUpgrade, MatchPlayerAbilityUpgradeModel>();
                     x.CreateMap<MatchPickBan, MatchPickBanModel>();
@@ -401,8 +407,8 @@ namespace SteamWebAPI2
                     #region Endpoint: TFItems
 
                     x.CreateMap<GoldenWrench, GoldenWrenchModel>();
-                    x.CreateMap<GoldenWrenchResultContainer, GoldenWrenchModel>().ConstructUsing(
-                        src => Mapper.Map<GoldenWrenchResult, GoldenWrenchModel>(src.Result)
+                    x.CreateMap<GoldenWrenchResultContainer, IReadOnlyCollection<GoldenWrenchModel>>().ConstructUsing(
+                        src => Mapper.Map<IList<GoldenWrench>, IReadOnlyCollection<GoldenWrenchModel>>(src.Result.GoldenWrenches)
                     );
 
                     #endregion
@@ -416,6 +422,7 @@ namespace SteamWebAPI2
                     x.CreateMap<AssetClassInfo, AssetClassInfoModel>();
                     x.CreateMap<AssetClassMarketAction, AssetClassMarketActionModel>();
                     x.CreateMap<AssetClassTag, AssetClassTagModel>();
+                    x.CreateMap<AssetClassInfoResult, AssetClassInfoResultModel>();
                     x.CreateMap<AssetClassInfoResultContainer, AssetClassInfoResultModel>().ConstructUsing(
                         src => Mapper.Map<AssetClassInfoResult, AssetClassInfoResultModel>(src.Result)
                     );
@@ -425,6 +432,7 @@ namespace SteamWebAPI2
                     x.CreateMap<AssetClass, AssetClassModel>();
                     x.CreateMap<AssetTags, AssetTagsModel>();
                     x.CreateMap<AssetTagIds, AssetTagIdsModel>();
+                    x.CreateMap<AssetPriceResult, AssetPriceResultModel>();
                     x.CreateMap<AssetPriceResultContainer, AssetPriceResultModel>().ConstructUsing(
                         src => Mapper.Map<AssetPriceResult, AssetPriceResultModel>(src.Result)
                     );
@@ -443,6 +451,15 @@ namespace SteamWebAPI2
                     x.CreateMap<StoreFilter, StoreFilterModel>();
                     x.CreateMap<StoreHomePageData, StoreHomePageDataModel>();
                     x.CreateMap<StoreMetaDataResult, StoreMetaDataModel>();
+                    x.CreateMap<StorePlayerClassData, StorePlayerClassDataModel>();
+                    x.CreateMap<StorePopularItem, StorePopularItemModel>();
+                    x.CreateMap<StorePrefab, StorePrefabModel>();
+                    x.CreateMap<StoreSorterId, StoreSorterIdModel>();
+                    x.CreateMap<StoreSorter, StoreSorterModel>();
+                    x.CreateMap<StoreSorting, StoreSortingModel>();
+                    x.CreateMap<StoreTabChild, StoreTabChildModel>();
+                    x.CreateMap<StoreTab, StoreTabModel>();
+                    x.CreateMap<StoreSortingPrefab, StoreSortingPrefabModel>();
                     x.CreateMap<StoreMetaDataResultContainer, StoreMetaDataModel>().ConstructUsing(
                         src => Mapper.Map<StoreMetaDataResult, StoreMetaDataModel>(src.Result)
                     );
@@ -550,6 +567,8 @@ namespace SteamWebAPI2
             {
                 mapper = config.CreateMapper();
             }
+
+            isInitialized = true;
         }
 
         public static void Reset()

--- a/SteamWebAPI2/AutoMapperConfiguration.cs
+++ b/SteamWebAPI2/AutoMapperConfiguration.cs
@@ -19,6 +19,9 @@ using SteamWebAPI2.Models.SteamStore;
 using SteamWebAPI2.Models.TF2;
 using SteamWebAPI2.Utilities;
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace SteamWebAPI2
 {
@@ -35,8 +38,32 @@ namespace SteamWebAPI2
             {
                 config = new MapperConfiguration(x =>
                 {
+                    x.CreateMap<ISteamWebResponse<ServerStatusResultContainer>, ISteamWebResponse<ServerStatusModel>>();
+                    x.CreateMap<ISteamWebResponse<GameItemResultContainer>, ISteamWebResponse<IReadOnlyCollection<GameItemModel>>>();
+                    x.CreateMap<ISteamWebResponse<HeroResultContainer>, ISteamWebResponse<IReadOnlyCollection<HeroModel>>>();
+                    x.CreateMap<ISteamWebResponse<ItemIconPathResultContainer>, ISteamWebResponse<string>>();
+                    x.CreateMap<ISteamWebResponse<RarityResultContainer>, ISteamWebResponse<IReadOnlyCollection<RarityModel>>>();
+                    x.CreateMap<ISteamWebResponse<ItemIconPathResultContainer>, ISteamWebResponse<string>>();
+                    x.CreateMap<ISteamWebResponse<ItemIconPathResultContainer>, ISteamWebResponse<string>>();
+                    x.CreateMap<ISteamWebResponse<ItemIconPathResultContainer>, ISteamWebResponse<string>>();
+                    x.CreateMap<ISteamWebResponse<ItemIconPathResultContainer>, ISteamWebResponse<string>>();
+                    x.CreateMap<ISteamWebResponse<ItemIconPathResultContainer>, ISteamWebResponse<string>>();
+                    x.CreateMap<ISteamWebResponse<ItemIconPathResultContainer>, ISteamWebResponse<string>>();
+                    x.CreateMap<ISteamWebResponse<ItemIconPathResultContainer>, ISteamWebResponse<string>>();
+
+                    #region Endpoint: DOTA2Econ
+
                     x.CreateMap<Hero, HeroModel>();
+                    x.CreateMap<HeroResultContainer, IReadOnlyCollection<HeroModel>>().ConstructUsing(
+                        src => Mapper.Map<IList<Hero>, IReadOnlyCollection<HeroModel>>(src.Result.Heroes)
+                    );
+
                     x.CreateMap<GameItem, GameItemModel>();
+                    x.CreateMap<GameItemResultContainer, IReadOnlyCollection<GameItemModel>>().ConstructUsing(
+                        src => Mapper.Map<IList<GameItem>, IReadOnlyCollection<GameItemModel>>(src.Result.Items)
+                    );
+
+                    x.CreateMap<ItemIconPathResultContainer, string>().ConstructUsing(src => src.Result.Path);
 
                     x.CreateMap<SchemaResult, Steam.Models.TF2.SchemaModel>();
                     x.CreateMap<SchemaQualities, Steam.Models.TF2.SchemaQualitiesModel>();
@@ -58,142 +85,40 @@ namespace SteamWebAPI2
                     x.CreateMap<SchemaKillEaterScoreType, Steam.Models.TF2.SchemaKillEaterScoreTypeModel>();
                     x.CreateMap<SchemaStringLookup, Steam.Models.TF2.SchemaStringLookupModel>();
                     x.CreateMap<SchemaString, Steam.Models.TF2.SchemaStringModel>();
+                    x.CreateMap<SchemaResultContainer, Steam.Models.TF2.SchemaModel>().ConstructUsing(
+                        src => Mapper.Map<SchemaResult, Steam.Models.TF2.SchemaModel>(src.Result)
+                    );
 
-                    x.CreateMap<SchemaResult, Steam.Models.DOTA2.SchemaModel>();
-                    //x.CreateMap<SchemaAdditionalHiddenBodygroups, SchemaAdditionalHiddenBodygroupsModel>();
-                    //x.CreateMap<SchemaAttributeControlledAttachedParticle, SchemaAttributeControlledAttachedParticleModel>();
-                    //x.CreateMap<SchemaAttribute, SchemaAttributeModel>();
-                    //x.CreateMap<SchemaCapabilities, SchemaCapabilitiesModel>();
-                    //x.CreateMap<SchemaItemAttribute, SchemaItemAttributeModel>();
-                    //x.CreateMap<SchemaItemLevel, SchemaItemLevelModel>();
-                    //x.CreateMap<SchemaItem, SchemaItemModel>();
-                    //x.CreateMap<SchemaLevel, SchemaLevelModel>();
-                    //x.CreateMap<SchemaItemSetAttribute, SchemaItemSetAttributeModel>();
-                    //x.CreateMap<SchemaItemSet, SchemaItemSetModel>();
-                    //x.CreateMap<SchemaKillEaterScoreType, SchemaKillEaterScoreTypeModel>();
-                    //x.CreateMap<SchemaOriginName, SchemaOriginNameModel>();
-                    //x.CreateMap<SchemaPerClassLoadoutSlots, SchemaPerClassLoadoutSlotsModel>();
-                    //x.CreateMap<SchemaQualities, SchemaQualitiesModel>();
-                    //x.CreateMap<SchemaStringLookup, SchemaStringLookupModel>();
-                    //x.CreateMap<SchemaString, SchemaStringModel>();
-                    //x.CreateMap<SchemaStyle, SchemaStyleModel>();
-                    //x.CreateMap<SchemaTool, SchemaToolModel>();
-                    //x.CreateMap<SchemaUsageCapabilities, SchemaUsageCapabilitiesModel>();
+                    x.CreateMap<Rarity, RarityModel>();
+                    x.CreateMap<RarityResultContainer, IReadOnlyCollection<RarityModel>>().ConstructUsing(
+                        src => Mapper.Map<IList<Rarity>, IReadOnlyCollection<RarityModel>>(src.Result.Rarities)
+                    );
 
-                    x.CreateMap<StoreBanner, StoreBannerModel>();
-                    x.CreateMap<StoreCarouselData, StoreCarouselDataModel>();
-                    x.CreateMap<StoreConfig, StoreConfigModel>();
-                    x.CreateMap<StoreDropdownData, StoreDropdownDataModel>();
-                    x.CreateMap<StoreDropdown, StoreDropdownModel>();
-                    x.CreateMap<StoreFilterAllElement, StoreFilterAllElementModel>();
-                    x.CreateMap<StoreFilterElement, StoreFilterElementModel>();
-                    x.CreateMap<StoreFilter, StoreFilterModel>();
-                    x.CreateMap<StoreHomePageData, StoreHomePageDataModel>();
-                    x.CreateMap<StoreMetaDataResult, StoreMetaDataModel>();
-                    x.CreateMap<StorePlayerClassData, StorePlayerClassDataModel>();
-                    x.CreateMap<StorePopularItem, StorePopularItemModel>();
-                    x.CreateMap<StorePrefab, StorePrefabModel>();
-                    x.CreateMap<StoreSorterId, StoreSorterIdModel>();
-                    x.CreateMap<StoreSorter, StoreSorterModel>();
-                    x.CreateMap<StoreSorting, StoreSortingModel>();
-                    x.CreateMap<StoreTabChild, StoreTabChildModel>();
-                    x.CreateMap<StoreTab, StoreTabModel>();
-                    x.CreateMap<StoreSortingPrefab, StoreSortingPrefabModel>();
+                    x.CreateMap<PrizePoolResultContainer, uint>().ConstructUsing(src => src.Result.PrizePool);
 
-                    x.CreateMap<GameClientResult, GameClientResultModel>();
+                    #endregion
 
-                    x.CreateMap<BadgesResult, BadgesResultModel>();
-                    x.CreateMap<Badge, BadgeModel>();
-                    x.CreateMap<BadgeQuest, BadgeQuestModel>();
+                    #region Endpoint: DOTA2Fantasy
 
-                    x.CreateMap<OwnedGame, OwnedGameModel>();
-                    x.CreateMap<OwnedGamesResult, OwnedGamesResultModel>();
+                    x.CreateMap<PlayerOfficialInfoResult, PlayerOfficialInfoModel>();
+                    x.CreateMap<PlayerOfficialInfoResultContainer, PlayerOfficialInfoModel>().ConstructUsing(
+                        src => Mapper.Map<PlayerOfficialInfoResult, PlayerOfficialInfoModel>(src.Result)
+                    );
 
-                    x.CreateMap<RecentlyPlayedGame, RecentlyPlayedGameModel>();
-                    x.CreateMap<RecentlyPlayedGameResult, RecentlyPlayedGamesResultModel>();
-
-                    x.CreateMap<SteamApp, SteamAppModel>();
-                    x.CreateMap<SteamAppUpToDateCheckResult, SteamAppUpToDateCheckModel>();
-
-                    x.CreateMap<AssetClassAction, AssetClassActionModel>();
-                    x.CreateMap<AssetClassAppDataFilter, AssetClassAppDataFilterModel>();
-                    x.CreateMap<AssetClassAppData, AssetClassAppDataModel>();
-                    x.CreateMap<AssetClassDescription, AssetClassDescriptionModel>();
-                    x.CreateMap<AssetClassInfo, AssetClassInfoModel>();
-                    x.CreateMap<AssetClassInfoResult, AssetClassInfoResultModel>();
-                    x.CreateMap<AssetClassMarketAction, AssetClassMarketActionModel>();
-                    x.CreateMap<AssetClassTag, AssetClassTagModel>();
-
-                    x.CreateMap<AssetPrices, AssetPricesModel>();
-                    x.CreateMap<Asset, AssetModel>();
-                    x.CreateMap<AssetClass, AssetClassModel>();
-                    x.CreateMap<AssetTags, AssetTagsModel>();
-                    x.CreateMap<AssetTagIds, AssetTagIdsModel>();
-                    x.CreateMap<AssetPriceResult, AssetPriceResultModel>();
-
-                    x.CreateMap<NewsItem, NewsItemModel>();
-                    x.CreateMap<SteamNewsResult, SteamNewsResultModel>();
-
-                    x.CreateMap<UGCFileDetails, UGCFileDetailsModel>();
-
-                    x.CreateMap<PlayerSummary, PlayerSummaryModel>();
-
-                    x.CreateMap<Friend, FriendModel>();
-
-                    x.CreateMap<PlayerBans, PlayerBansModel>();
-
-                    x.CreateMap<GlobalAchievementPercentage, GlobalAchievementPercentageModel>();
-
-                    x.CreateMap<GlobalStat, GlobalStatModel>();
-
-                    x.CreateMap<PlayerAchievementResult, PlayerAchievementResultModel>();
-                    x.CreateMap<PlayerAchievement, PlayerAchievementModel>();
-
-                    x.CreateMap<SchemaForGameResult, SchemaForGameResultModel>();
-                    x.CreateMap<AvailableGameStats, AvailableGameStatsModel>();
-                    x.CreateMap<SchemaGameAchievement, SchemaGameAchievementModel>();
-                    x.CreateMap<SchemaGameStat, SchemaGameStatModel>();
-
-                    x.CreateMap<UserStatsForGameResult, UserStatsForGameResultModel>();
-                    x.CreateMap<UserStatAchievement, UserStatAchievementModel>();
-                    x.CreateMap<UserStat, UserStatModel>();
-
-                    x.CreateMap<GoldenWrench, GoldenWrenchModel>();
-
-                    x.CreateMap<SteamServerInfo, SteamServerInfoModel>();
-
-                    x.CreateMap<SteamInterface, SteamInterfaceModel>();
-                    x.CreateMap<SteamMethod, SteamMethodModel>();
-                    x.CreateMap<SteamParameter, SteamParameterModel>();
-
-                    x.CreateMap<ServerStatusApp, ServerStatusAppModel>();
-                    x.CreateMap<ServerStatusResult, ServerStatusModel>();
-                    x.CreateMap<ServerStatusMatchmaking, ServerStatusMatchmakingModel>();
-                    x.CreateMap<ServerStatusServices, ServerStatusServicesModel>();
-                    x.CreateMap<ServerStatusDatacenter, ServerStatusDatacenterModel>();
-
-                    x.CreateMap<ProPlayerListResult, ProPlayerDetailModel>();
                     x.CreateMap<ProPlayerInfo, ProPlayerInfoModel>();
                     x.CreateMap<ProPlayerLeaderboardModel, ProPlayerLeaderboard>();
+                    x.CreateMap<ProPlayerListResult, ProPlayerDetailModel>();
+                    x.CreateMap<ProPlayerListResultContainer, ProPlayerDetailModel>().ConstructUsing(
+                        src => Mapper.Map<ProPlayerListResult, ProPlayerDetailModel>(src.Result)
+                    );
 
-                    x.CreateMap<MatchDetailResult, MatchDetailModel>();
-                    x.CreateMap<MatchPlayer, MatchPlayerModel>();
-                    x.CreateMap<MatchPlayerAbilityUpgrade, MatchPlayerAbilityUpgradeModel>();
-                    x.CreateMap<MatchPickBan, MatchPickBanModel>();
+                    #endregion
 
-                    x.CreateMap<MatchHistoryMatch, MatchHistoryMatchModel>();
-                    x.CreateMap<MatchHistoryPlayer, MatchHistoryPlayerModel>();
-                    x.CreateMap<MatchHistoryResult, MatchHistoryModel>();
+                    #region Endpoint: DOTA2Match
 
-                    x.CreateMap<TeamInfo, TeamInfoModel>();
-
-                    x.CreateMap<EconItemResult, EconItemResultModel>();
-                    x.CreateMap<EconItem, EconItemModel>();
-                    x.CreateMap<EconItemAttribute, EconItemAttributeModel>();
-                    x.CreateMap<EconItemAttributeAccountInfo, EconItemAttributeAccountInfoModel>();
-                    x.CreateMap<EconItemEquipped, EconItemEquippedModel>();
-
-                    x.CreateMap<MatchHistoryBySequenceNumberResult, MatchHistoryModel>();
+                    x.CreateMap<LeagueResultContainer, IReadOnlyCollection<LeagueModel>>().ConstructUsing(
+                        src => Mapper.Map<IList<League>, IReadOnlyCollection<LeagueModel>>(src.Result.Leagues)
+                    );
 
                     x.CreateMap<LiveLeagueGame, LiveLeagueGameModel>();
                     x.CreateMap<LiveLeagueGameTeamDireInfo, LiveLeagueGameTeamDireInfoModel>();
@@ -206,6 +131,287 @@ namespace SteamWebAPI2
                     x.CreateMap<LiveLeagueGamePick, LiveLeagueGamePickModel>();
                     x.CreateMap<LiveLeagueGameTeamRadiantDetail, LiveLeagueGameTeamRadiantDetailModel>();
                     x.CreateMap<LiveLeagueGamePlayerDetail, LiveLeagueGamePlayerDetailModel>();
+                    x.CreateMap<LiveLeagueGameResultContainer, IReadOnlyCollection<LiveLeagueGameModel>>().ConstructUsing(
+                        src => Mapper.Map<IList<LiveLeagueGame>, IReadOnlyCollection<LiveLeagueGameModel>>(src.Result.Games)
+                    );
+
+                    x.CreateMap<MatchDetailResult, MatchDetailModel>();
+                    x.CreateMap<MatchPlayer, MatchPlayerModel>();
+                    x.CreateMap<MatchPlayerAbilityUpgrade, MatchPlayerAbilityUpgradeModel>();
+                    x.CreateMap<MatchPickBan, MatchPickBanModel>();
+                    x.CreateMap<MatchDetailResultContainer, MatchDetailModel>().ConstructUsing(
+                        src => Mapper.Map<MatchDetailResult, MatchDetailModel>(src.Result)
+                    );
+
+                    x.CreateMap<MatchHistoryMatch, MatchHistoryMatchModel>();
+                    x.CreateMap<MatchHistoryPlayer, MatchHistoryPlayerModel>();
+                    x.CreateMap<MatchHistoryResult, MatchHistoryModel>();
+                    x.CreateMap<MatchHistoryResultContainer, MatchHistoryModel>().ConstructUsing(
+                        src => Mapper.Map<MatchHistoryResult, MatchHistoryModel>(src.Result)
+                    );
+
+                    x.CreateMap<MatchHistoryBySequenceNumberResult, MatchHistoryModel>();
+                    x.CreateMap<MatchHistoryBySequenceNumberResultContainer, IReadOnlyCollection<MatchHistoryMatchModel>>().ConstructUsing(
+                        src => Mapper.Map<IList<MatchHistoryMatch>, IReadOnlyCollection<MatchHistoryMatchModel>>(src.Result.Matches)
+                    );
+
+                    x.CreateMap<TeamInfo, TeamInfoModel>();
+                    x.CreateMap<TeamInfoResultContainer, IReadOnlyCollection<TeamInfoModel>>().ConstructUsing(
+                        src => Mapper.Map<IList<TeamInfo>, IReadOnlyCollection<TeamInfoModel>>(src.Result.Teams)
+                    );
+
+                    #endregion
+
+                    #region Endpoint: EconService
+
+                    x.CreateMap<Models.SteamEconomy.TradeStatus, Steam.Models.SteamEconomy.TradeStatus>();
+                    x.CreateMap<Models.SteamEconomy.TradeOfferState, Steam.Models.SteamEconomy.TradeOfferState>();
+                    x.CreateMap<Models.SteamEconomy.TradeOfferConfirmationMethod, Steam.Models.SteamEconomy.TradeOfferConfirmationMethod>();
+                    x.CreateMap<TradeAsset, TradeAssetModel>();
+                    x.CreateMap<TradedAsset, TradedAssetModel>();
+                    x.CreateMap<TradedCurrency, TradedCurrencyModel>();
+                    x.CreateMap<Trade, TradeModel>()
+                        .ForMember(dest => dest.TimeTradeStarted, opts => opts.MapFrom(source => source.TimeTradeStarted.ToDateTime()))
+                        .ForMember(dest => dest.TimeEscrowEnds, opts => opts.MapFrom(source => source.TimeEscrowEnds.ToDateTime()));
+                    x.CreateMap<TradeOffer, TradeOfferModel>()
+                        .ForMember(dest => dest.TimeCreated, opts => opts.MapFrom(source => source.TimeCreated.ToDateTime()))
+                        .ForMember(dest => dest.TimeEscrowEnds, opts => opts.MapFrom(source => source.TimeEscrowEnds.ToDateTime()))
+                        .ForMember(dest => dest.TimeExpiration, opts => opts.MapFrom(source => source.TimeExpiration.ToDateTime()))
+                        .ForMember(dest => dest.TimeUpdated, opts => opts.MapFrom(source => source.TimeUpdated.ToDateTime()));
+                    x.CreateMap<TradeHistoryResult, TradeHistoryModel>();
+                    x.CreateMap<TradeOfferResult, TradeOfferResultModel>();
+                    x.CreateMap<TradeOffersResult, TradeOffersResultModel>();
+                    x.CreateMap<TradeHistoryResultContainer, TradeHistoryModel>().ConstructUsing(
+                        src => Mapper.Map<TradeHistoryResult, TradeHistoryModel>(src.Result)
+                    );
+                    x.CreateMap<TradeOfferResultContainer, TradeOfferResultModel>().ConstructUsing(
+                        src => Mapper.Map<TradeOfferResult, TradeOfferResultModel>(src.Result)
+                    );
+                    x.CreateMap<TradeOffersResultContainer, TradeOffersResultModel>().ConstructUsing(
+                        src => Mapper.Map<TradeOffersResult, TradeOffersResultModel>(src.Result)
+                    );
+
+                    #endregion
+
+                    #region Endpoint: GCVersion
+
+                    x.CreateMap<GameClientResult, GameClientResultModel>();
+                    x.CreateMap<GameClientResultContainer, GameClientResultModel>().ConstructUsing(
+                        src => Mapper.Map<GameClientResult, GameClientResultModel>(src.Result)
+                    );
+
+                    #endregion
+
+                    #region Endpoint: PlayerService
+
+                    x.CreateMap<PlayingSharedGameResultContainer, ulong?>().ConstructUsing(src => src.Result.LenderSteamId);
+
+                    x.CreateMap<CommunityBadgeProgressResultContainer, IReadOnlyCollection<BadgeQuestModel>>().ConstructUsing(
+                        src => Mapper.Map<IList<BadgeQuest>, IReadOnlyCollection<BadgeQuestModel>>(src.Result.Quests)
+                    );
+
+                    x.CreateMap<Badge, BadgeModel>();
+                    x.CreateMap<BadgeQuest, BadgeQuestModel>();
+                    x.CreateMap<BadgesResult, BadgesResultModel>();
+                    x.CreateMap<BadgesResultContainer, BadgesResultModel>().ConstructUsing(
+                        src => Mapper.Map<BadgesResult, BadgesResultModel>(src.Result)
+                    );
+
+                    x.CreateMap<SteamLevelResultContainer, uint?>().ConstructUsing(src => src.Result.PlayerLevel);
+
+                    x.CreateMap<OwnedGame, OwnedGameModel>();
+                    x.CreateMap<OwnedGamesResult, OwnedGamesResultModel>();
+                    x.CreateMap<OwnedGamesResultContainer, OwnedGamesResultModel>().ConstructUsing(
+                        src => Mapper.Map<OwnedGamesResult, OwnedGamesResultModel>(src.Result)
+                    );
+
+                    x.CreateMap<RecentlyPlayedGame, RecentlyPlayedGameModel>();
+                    x.CreateMap<RecentlyPlayedGameResult, RecentlyPlayedGamesResultModel>();
+                    x.CreateMap<RecentlyPlayedGameResultContainer, RecentlyPlayedGamesResultModel>().ConstructUsing(
+                        src => Mapper.Map<RecentlyPlayedGameResult, RecentlyPlayedGamesResultModel>(src.Result)
+                    );
+
+                    #endregion
+
+                    #region Endpoint: SteamApps
+
+                    x.CreateMap<SteamApp, SteamAppModel>();
+                    x.CreateMap<SteamAppListResultContainer, IReadOnlyCollection<SteamAppModel>>().ConstructUsing(
+                        src => Mapper.Map<IList<SteamApp>, IReadOnlyCollection<SteamAppModel>>(src.Result.Apps)
+                    );
+
+                    x.CreateMap<SteamAppUpToDateCheckResult, SteamAppUpToDateCheckModel>();
+                    x.CreateMap<SteamAppUpToDateCheckResultContainer, SteamAppUpToDateCheckModel>().ConstructUsing(
+                        src => Mapper.Map<SteamAppUpToDateCheckResult, SteamAppUpToDateCheckModel>(src.Result)
+                    );
+
+                    #endregion
+
+                    #region Endpoint: SteamNews
+
+                    x.CreateMap<NewsItem, NewsItemModel>();
+                    x.CreateMap<SteamNewsResult, SteamNewsResultModel>();
+                    x.CreateMap<SteamNewsResultContainer, SteamNewsResultModel>().ConstructUsing(
+                        src => Mapper.Map<SteamNewsResult, SteamNewsResultModel>(src.Result)
+                    );
+
+                    #endregion
+
+                    #region Endpoint: SteamRemoteStorage
+
+                    x.CreateMap<UGCFileDetails, UGCFileDetailsModel>();
+
+                    #endregion
+
+                    #region Endpoint: SteamUser
+
+                    x.CreateMap<PlayerSummary, PlayerSummaryModel>();
+                    x.CreateMap<PlayerSummaryResultContainer, PlayerSummaryModel>().ConstructUsing(
+                        src => Mapper.Map<PlayerSummary, PlayerSummaryModel>(src.Result.Players[0])
+                    );
+                    x.CreateMap<PlayerSummaryResultContainer, IReadOnlyCollection<PlayerSummaryModel>>().ConstructUsing(
+                        src => Mapper.Map<IList<PlayerSummary>, IReadOnlyCollection<PlayerSummaryModel>>(src.Result.Players)
+                    );
+
+                    x.CreateMap<Friend, FriendModel>();
+                    x.CreateMap<FriendsListResultContainer, IReadOnlyCollection<FriendModel>>().ConstructUsing(
+                        src => Mapper.Map<IList<Friend>, IReadOnlyCollection<FriendModel>>(src.Result.Friends)
+                    );
+
+                    x.CreateMap<PlayerBans, PlayerBansModel>();
+                    x.CreateMap<PlayerBansContainer, IReadOnlyCollection<PlayerBansModel>>().ConstructUsing(
+                        src => Mapper.Map<IList<PlayerBans>, IReadOnlyCollection<PlayerBansModel>>(src.PlayerBans)
+                    );
+
+                    x.CreateMap<UserGroupGid, ulong>().ConstructUsing(src => src.Gid);
+
+                    x.CreateMap<UserGroupListResultContainer, IReadOnlyCollection<ulong>>().ConstructUsing(
+                        src => Mapper.Map<IList<UserGroupGid>, IReadOnlyCollection<ulong>>(src.Result.Groups)
+                    );
+
+                    x.CreateMap<ResolveVanityUrlResultContainer, ulong>().ConstructUsing(src => src.Result.SteamId);
+
+                    #endregion
+
+                    #region Endpoint: SteamUserStats
+
+                    x.CreateMap<GlobalAchievementPercentage, GlobalAchievementPercentageModel>();
+                    x.CreateMap<GlobalAchievementPercentagesResultContainer, IReadOnlyCollection<GlobalAchievementPercentageModel>>().ConstructUsing(
+                        src => Mapper.Map<IList<GlobalAchievementPercentage>, IReadOnlyCollection<GlobalAchievementPercentageModel>>(src.Result.AchievementPercentages)
+                    );
+
+                    x.CreateMap<GlobalStatsForGameResultContainer, IReadOnlyCollection<GlobalStatModel>>().ConstructUsing(
+                        src => Mapper.Map<IList<GlobalStat>, IReadOnlyCollection<GlobalStatModel>>(src.Result.GlobalStats)
+                    );
+
+                    x.CreateMap<CurrentPlayersResultContainer, uint>().ConstructUsing(src => src.Result.PlayerCount);
+
+                    x.CreateMap<PlayerAchievement, PlayerAchievementModel>();
+                    x.CreateMap<PlayerAchievementResult, PlayerAchievementResultModel>();
+                    x.CreateMap<PlayerAchievementResultContainer, PlayerAchievementResultModel>().ConstructUsing(
+                        src => Mapper.Map<PlayerAchievementResult, PlayerAchievementResultModel>(src.Result)
+                    );
+
+                    x.CreateMap<AvailableGameStats, AvailableGameStatsModel>();
+                    x.CreateMap<SchemaGameAchievement, SchemaGameAchievementModel>();
+                    x.CreateMap<SchemaGameStat, SchemaGameStatModel>();
+                    x.CreateMap<SchemaForGameResult, SchemaForGameResultModel>();
+                    x.CreateMap<SchemaForGameResultContainer, SchemaForGameResultModel>().ConstructUsing(
+                        src => Mapper.Map<SchemaForGameResult, SchemaForGameResultModel>(src.Result)
+                    );
+
+                    x.CreateMap<UserStatAchievement, UserStatAchievementModel>();
+                    x.CreateMap<UserStat, UserStatModel>();
+                    x.CreateMap<UserStatsForGameResult, UserStatsForGameResultModel>();
+                    x.CreateMap<UserStatsForGameResultContainer, UserStatsForGameResultModel>().ConstructUsing(
+                        src => Mapper.Map<UserStatsForGameResult, UserStatsForGameResultModel>(src.Result)
+                    );
+
+                    #endregion
+
+                    #region Endpoint: SteamWebAPIUtil
+
+                    x.CreateMap<SteamServerInfo, SteamServerInfoModel>();
+
+                    x.CreateMap<SteamInterface, SteamInterfaceModel>();
+                    x.CreateMap<SteamMethod, SteamMethodModel>();
+                    x.CreateMap<SteamParameter, SteamParameterModel>();
+                    x.CreateMap<SteamApiListContainer, IReadOnlyCollection<SteamInterfaceModel>>().ConstructUsing(
+                        src => Mapper.Map<IList<SteamInterface>, IReadOnlyCollection<SteamInterfaceModel>>(src.Result.Interfaces)
+                    );
+
+                    #endregion
+
+                    #region Endpoint: TFItems
+
+                    x.CreateMap<GoldenWrench, GoldenWrenchModel>();
+                    x.CreateMap<GoldenWrenchResultContainer, GoldenWrenchModel>().ConstructUsing(
+                        src => Mapper.Map<GoldenWrenchResult, GoldenWrenchModel>(src.Result)
+                    );
+
+                    #endregion
+
+                    #region Endpoint: SteamEconomy
+
+                    x.CreateMap<AssetClassAction, AssetClassActionModel>();
+                    x.CreateMap<AssetClassAppDataFilter, AssetClassAppDataFilterModel>();
+                    x.CreateMap<AssetClassAppData, AssetClassAppDataModel>();
+                    x.CreateMap<AssetClassDescription, AssetClassDescriptionModel>();
+                    x.CreateMap<AssetClassInfo, AssetClassInfoModel>();
+                    x.CreateMap<AssetClassMarketAction, AssetClassMarketActionModel>();
+                    x.CreateMap<AssetClassTag, AssetClassTagModel>();
+                    x.CreateMap<AssetClassInfoResultContainer, AssetClassInfoResultModel>().ConstructUsing(
+                        src => Mapper.Map<AssetClassInfoResult, AssetClassInfoResultModel>(src.Result)
+                    );
+
+                    x.CreateMap<AssetPrices, AssetPricesModel>();
+                    x.CreateMap<Asset, AssetModel>();
+                    x.CreateMap<AssetClass, AssetClassModel>();
+                    x.CreateMap<AssetTags, AssetTagsModel>();
+                    x.CreateMap<AssetTagIds, AssetTagIdsModel>();
+                    x.CreateMap<AssetPriceResultContainer, AssetPriceResultModel>().ConstructUsing(
+                        src => Mapper.Map<AssetPriceResult, AssetPriceResultModel>(src.Result)
+                    );
+
+                    #endregion
+
+                    x.CreateMap<SchemaUrlResultContainer, string>().ConstructUsing(src => src.Result.ItemsGameUrl);
+
+                    x.CreateMap<StoreBanner, StoreBannerModel>();
+                    x.CreateMap<StoreCarouselData, StoreCarouselDataModel>();
+                    x.CreateMap<StoreConfig, StoreConfigModel>();
+                    x.CreateMap<StoreDropdownData, StoreDropdownDataModel>();
+                    x.CreateMap<StoreDropdown, StoreDropdownModel>();
+                    x.CreateMap<StoreFilterAllElement, StoreFilterAllElementModel>();
+                    x.CreateMap<StoreFilterElement, StoreFilterElementModel>();
+                    x.CreateMap<StoreFilter, StoreFilterModel>();
+                    x.CreateMap<StoreHomePageData, StoreHomePageDataModel>();
+                    x.CreateMap<StoreMetaDataResult, StoreMetaDataModel>();
+                    x.CreateMap<StoreMetaDataResultContainer, StoreMetaDataModel>().ConstructUsing(
+                        src => Mapper.Map<StoreMetaDataResult, StoreMetaDataModel>(src.Result)
+                    );
+
+                    x.CreateMap<StoreStatusResultContainer, uint>().ConstructUsing(src => src.Result.StoreStatus);
+
+                    x.CreateMap<ServerStatusApp, ServerStatusAppModel>();
+                    x.CreateMap<ServerStatusResult, ServerStatusModel>();
+                    x.CreateMap<ServerStatusMatchmaking, ServerStatusMatchmakingModel>();
+                    x.CreateMap<ServerStatusServices, ServerStatusServicesModel>();
+                    x.CreateMap<ServerStatusDatacenter, ServerStatusDatacenterModel>();
+                    x.CreateMap<ServerStatusResultContainer, ServerStatusModel>().ConstructUsing(
+                        src => Mapper.Map<ServerStatusResult, ServerStatusModel>(src.Result)
+                    );
+
+                    x.CreateMap<EconItem, EconItemModel>();
+                    x.CreateMap<EconItemAttribute, EconItemAttributeModel>();
+                    x.CreateMap<EconItemAttributeAccountInfo, EconItemAttributeAccountInfoModel>();
+                    x.CreateMap<EconItemEquipped, EconItemEquippedModel>();
+                    x.CreateMap<EconItemResult, EconItemResultModel>();
+                    x.CreateMap<EconItemResultContainer, EconItemResultModel>().ConstructUsing(
+                        src => Mapper.Map<EconItemResult, EconItemResultModel>(src.Result)
+                    );
+
+                    #region Endpoint: SteamStore
 
                     x.CreateMap<Data, StoreAppDetailsDataModel>();
                     x.CreateMap<SupportInfo, StoreSupportInfoModel>();
@@ -238,6 +444,8 @@ namespace SteamWebAPI2
                     x.CreateMap<FeaturedMac, StoreFeaturedMacModel>();
                     x.CreateMap<FeaturedWin, StoreFeaturedWinModel>();
                     x.CreateMap<LargeCapsule, StoreLargeCapsuleModel>();
+
+                    #endregion
 
                     x.CreateMap<ProfileInGameInfo, InGameInfoModel>()
                         .ForMember(dest => dest.GameIcon, opts => opts.MapFrom(source => source.GameIcon))
@@ -276,26 +484,10 @@ namespace SteamWebAPI2
                         .ForMember(dest => dest.IsVacBanned, opts => opts.MapFrom(source => source.VacBanned == 1 ? true : false))
                         .ForMember(dest => dest.VisibilityState, opts => opts.MapFrom(source => source.VisibilityState))
                         .ForMember(dest => dest.InGameServerIP, opts => opts.MapFrom(source => source.InGameServerIP))
-                        .ForMember(dest => dest.InGameInfo, opts => opts.MapFrom(source => source.InGameInfo));
-
-                    x.CreateMap<Models.SteamEconomy.TradeStatus, Steam.Models.SteamEconomy.TradeStatus>();
-                    x.CreateMap<Models.SteamEconomy.TradeOfferState, Steam.Models.SteamEconomy.TradeOfferState>();
-                    x.CreateMap<Models.SteamEconomy.TradeOfferConfirmationMethod, Steam.Models.SteamEconomy.TradeOfferConfirmationMethod>();
-                    x.CreateMap<TradeAsset, TradeAssetModel>();
-                    x.CreateMap<TradedAsset, TradedAssetModel>();
-                    x.CreateMap<TradedCurrency, TradedCurrencyModel>();
-                    x.CreateMap<Trade, TradeModel>()
-                        .ForMember(dest => dest.TimeTradeStarted, opts => opts.MapFrom(source => source.TimeTradeStarted.ToDateTime()))
-                        .ForMember(dest => dest.TimeEscrowEnds, opts => opts.MapFrom(source => source.TimeEscrowEnds.ToDateTime()));
-                    x.CreateMap<TradeOffer, TradeOfferModel>()
-                        .ForMember(dest => dest.TimeCreated, opts => opts.MapFrom(source => source.TimeCreated.ToDateTime()))
-                        .ForMember(dest => dest.TimeEscrowEnds, opts => opts.MapFrom(source => source.TimeEscrowEnds.ToDateTime()))
-                        .ForMember(dest => dest.TimeExpiration, opts => opts.MapFrom(source => source.TimeExpiration.ToDateTime()))
-                        .ForMember(dest => dest.TimeUpdated, opts => opts.MapFrom(source => source.TimeUpdated.ToDateTime()));
-                    x.CreateMap<TradeHistoryResult, TradeHistoryModel>();
-                    x.CreateMap<TradeOfferResult, TradeOfferResultModel>();
-                    x.CreateMap<TradeOffersResult, TradeOffersResultModel>();
+                        .ForMember(dest => dest.InGameInfo, opts => opts.MapFrom(source => source.InGameInfo))
+                        .ForMember(dest => dest.Nickname, opts => opts.Ignore());
                 });
+
             }
 
             if (mapper == null)

--- a/SteamWebAPI2/AutoMapperConfiguration.cs
+++ b/SteamWebAPI2/AutoMapperConfiguration.cs
@@ -88,7 +88,7 @@ namespace SteamWebAPI2
                     CreateSteamWebResponseMap<MatchHistoryBySequenceNumberResultContainer, IReadOnlyCollection<MatchHistoryMatchModel>>(x);
                     CreateSteamWebResponseMap<TeamInfoResultContainer, IReadOnlyCollection<TeamInfoModel>>(x);
                     CreateSteamWebResponseMap<EconItemResultContainer, EconItemResultModel>(x);
-                    CreateSteamWebResponseMap<SchemaResultContainer, Steam.Models.DOTA2.SchemaModel>(x);
+                    //CreateSteamWebResponseMap<SchemaResultContainer, Steam.Models.DOTA2.SchemaModel>(x);
                     CreateSteamWebResponseMap<SchemaResultContainer, Steam.Models.TF2.SchemaModel>(x);
                     CreateSteamWebResponseMap<SchemaUrlResultContainer, string>(x);
                     CreateSteamWebResponseMap<StoreMetaDataResultContainer, StoreMetaDataModel>(x);
@@ -162,9 +162,21 @@ namespace SteamWebAPI2
                     x.CreateMap<SchemaResultContainer, Steam.Models.TF2.SchemaModel>().ConvertUsing(
                         src => Mapper.Map<SchemaResult, Steam.Models.TF2.SchemaModel>(src.Result)
                     );
-                    x.CreateMap<SchemaResultContainer, Steam.Models.DOTA2.SchemaModel>().ConvertUsing(
-                        src => Mapper.Map<SchemaResult, Steam.Models.DOTA2.SchemaModel>(src.Result)
-                    );
+
+                    // TODO: Rework the way Schema models are used for different games (TF2 / DOTA2)
+                    //x.CreateMap<SchemaQualities, Steam.Models.DOTA2.SchemaQualityModel>()
+                    //    .ForMember(dest => dest.Name, opts => opts.Ignore())
+                    //    .ForMember(dest => dest.Value, opts => opts.Ignore())
+                    //    .ForMember(dest => dest.HexColor, opts => opts.Ignore());
+                    //x.CreateMap<SchemaResult, Steam.Models.DOTA2.SchemaModel>()
+                    //    .ForMember(dest => dest.GameInfo, opts => opts.Ignore())
+                    //    .ForMember(dest => dest.Rarities, opts => opts.Ignore())
+                    //    .ForMember(dest => dest.Colors, opts => opts.Ignore())
+                    //    .ForMember(dest => dest.Prefabs, opts => opts.Ignore())
+                    //    .ForMember(dest => dest.ItemAutographs, opts => opts.Ignore());
+                    //x.CreateMap<SchemaResultContainer, Steam.Models.DOTA2.SchemaModel>().ConvertUsing(
+                    //    src => Mapper.Map<SchemaResult, Steam.Models.DOTA2.SchemaModel>(src.Result)
+                    //);
 
                     x.CreateMap<Rarity, RarityModel>();
                     x.CreateMap<RarityResultContainer, IReadOnlyCollection<RarityModel>>().ConvertUsing(

--- a/SteamWebAPI2/AutoMapperConfiguration.cs
+++ b/SteamWebAPI2/AutoMapperConfiguration.cs
@@ -32,29 +32,85 @@ namespace SteamWebAPI2
 
         public static IMapper Mapper { get { return mapper; } }
 
+        private static SteamWebResponse<TDestination> ConstructSteamWebResponse<TSource, TDestination>(ISteamWebResponse<TSource> response)
+        {
+            var newResponse = new SteamWebResponse<TDestination>();
+            newResponse.ContentLength = response.ContentLength;
+            newResponse.ContentType = response.ContentType;
+            newResponse.ContentTypeCharSet = response.ContentTypeCharSet;
+            newResponse.Expires = response.Expires;
+            newResponse.LastModified = response.LastModified;
+            newResponse.Data = Mapper.Map<TSource, TDestination>(response.Data);
+            return newResponse;
+        }
+
+        private static void CreateSteamWebResponseMap<TSource, TDestination>(IMapperConfiguration config)
+        {
+            config.CreateMap<ISteamWebResponse<TSource>, ISteamWebResponse<TDestination>>()
+                .ConstructUsing(src => ConstructSteamWebResponse<TSource, TDestination>(src));
+        }
+
         public static void Initialize()
         {
             if (config == null)
             {
                 config = new MapperConfiguration(x =>
                 {
-                    x.CreateMap<ISteamWebResponse<ServerStatusResultContainer>, ISteamWebResponse<ServerStatusModel>>();
-                    x.CreateMap<ISteamWebResponse<GameItemResultContainer>, ISteamWebResponse<IReadOnlyCollection<GameItemModel>>>();
-                    x.CreateMap<ISteamWebResponse<HeroResultContainer>, ISteamWebResponse<IReadOnlyCollection<HeroModel>>>();
-                    x.CreateMap<ISteamWebResponse<ItemIconPathResultContainer>, ISteamWebResponse<string>>();
-                    x.CreateMap<ISteamWebResponse<RarityResultContainer>, ISteamWebResponse<IReadOnlyCollection<RarityModel>>>();
-                    x.CreateMap<ISteamWebResponse<ItemIconPathResultContainer>, ISteamWebResponse<string>>();
-                    x.CreateMap<ISteamWebResponse<ItemIconPathResultContainer>, ISteamWebResponse<string>>();
-                    x.CreateMap<ISteamWebResponse<ItemIconPathResultContainer>, ISteamWebResponse<string>>();
-                    x.CreateMap<ISteamWebResponse<ItemIconPathResultContainer>, ISteamWebResponse<string>>();
-                    x.CreateMap<ISteamWebResponse<ItemIconPathResultContainer>, ISteamWebResponse<string>>();
-                    x.CreateMap<ISteamWebResponse<ItemIconPathResultContainer>, ISteamWebResponse<string>>();
-                    x.CreateMap<ISteamWebResponse<ItemIconPathResultContainer>, ISteamWebResponse<string>>();
+                    CreateSteamWebResponseMap<ServerStatusResultContainer, ServerStatusModel>(x);
+                    CreateSteamWebResponseMap<GameItemResultContainer, IReadOnlyCollection<GameItemModel>>(x);
+                    CreateSteamWebResponseMap<HeroResultContainer, IReadOnlyCollection<HeroModel>>(x);
+                    CreateSteamWebResponseMap<ItemIconPathResultContainer, string>(x);
+                    CreateSteamWebResponseMap<RarityResultContainer, IReadOnlyCollection<RarityModel>>(x);
+                    CreateSteamWebResponseMap<PrizePoolResultContainer, uint>(x);
+                    CreateSteamWebResponseMap<PlayerOfficialInfoResultContainer, PlayerOfficialInfoModel>(x);
+                    CreateSteamWebResponseMap<ProPlayerListResultContainer, ProPlayerDetailModel>(x);
+                    CreateSteamWebResponseMap<LeagueResultContainer, IReadOnlyCollection<LeagueModel>>(x);
+                    CreateSteamWebResponseMap<LiveLeagueGameResultContainer, IReadOnlyCollection<LiveLeagueGameModel>>(x);
+                    CreateSteamWebResponseMap<MatchDetailResultContainer, MatchDetailModel>(x);
+                    CreateSteamWebResponseMap<MatchHistoryResultContainer, MatchHistoryModel>(x);
+                    CreateSteamWebResponseMap<MatchHistoryBySequenceNumberResultContainer, IReadOnlyCollection<MatchHistoryMatchModel>>(x);
+                    CreateSteamWebResponseMap<TeamInfoResultContainer, IReadOnlyCollection<TeamInfoModel>>(x);
+                    CreateSteamWebResponseMap<EconItemResultContainer, IReadOnlyCollection<EconItemResultModel>>(x);
+                    CreateSteamWebResponseMap<SchemaResultContainer, IReadOnlyCollection<Steam.Models.DOTA2.SchemaModel>>(x);
+                    CreateSteamWebResponseMap<SchemaUrlResultContainer, IReadOnlyCollection<string>>(x);
+                    CreateSteamWebResponseMap<StoreMetaDataResultContainer, IReadOnlyCollection<StoreMetaDataModel>>(x);
+                    CreateSteamWebResponseMap<StoreStatusResultContainer, IReadOnlyCollection<uint>>(x);
+                    CreateSteamWebResponseMap<TradeHistoryResultContainer, Steam.Models.SteamEconomy.TradeHistoryModel>(x);
+                    CreateSteamWebResponseMap<TradeOffersResultContainer, Steam.Models.SteamEconomy.TradeOffersResultModel>(x);
+                    CreateSteamWebResponseMap<TradeOfferResultContainer, Steam.Models.SteamEconomy.TradeOfferResultModel>(x);
+                    CreateSteamWebResponseMap<GameClientResultContainer, GameClientResultModel>(x);
+                    CreateSteamWebResponseMap<PlayingSharedGameResultContainer, ulong?>(x);
+                    CreateSteamWebResponseMap<CommunityBadgeProgressResultContainer, IReadOnlyCollection<BadgeQuestModel>>(x);
+                    CreateSteamWebResponseMap<BadgesResultContainer, BadgesResultModel>(x);
+                    CreateSteamWebResponseMap<SteamLevelResultContainer, uint?>(x);
+                    CreateSteamWebResponseMap<OwnedGamesResultContainer, OwnedGamesResultContainer>(x);
+                    CreateSteamWebResponseMap<RecentlyPlayedGameResultContainer, RecentlyPlayedGamesResultModel>(x);
+                    CreateSteamWebResponseMap<SteamAppListResultContainer, IReadOnlyCollection<SteamAppModel>>(x);
+                    CreateSteamWebResponseMap<SteamAppUpToDateCheckResultContainer, SteamAppUpToDateCheckModel>(x);
+                    CreateSteamWebResponseMap<AssetClassInfoResultContainer, AssetClassInfoResultModel>(x);
+                    CreateSteamWebResponseMap<AssetPriceResultContainer, AssetPriceResultModel>(x);
+                    CreateSteamWebResponseMap<SteamNewsResultContainer, SteamNewsResultModel>(x);
+                    CreateSteamWebResponseMap<UGCFileDetailsResultContainer, UGCFileDetailsModel>(x);
+                    CreateSteamWebResponseMap<PlayerSummaryResultContainer, PlayerSummaryModel>(x);
+                    CreateSteamWebResponseMap<PlayerSummaryResultContainer, IReadOnlyCollection<PlayerSummaryModel>>(x);
+                    CreateSteamWebResponseMap<FriendsListResultContainer, IReadOnlyCollection<FriendModel>>(x);
+                    CreateSteamWebResponseMap<PlayerBansContainer, IReadOnlyCollection<PlayerBansModel>>(x);
+                    CreateSteamWebResponseMap<UserGroupListResultContainer, IReadOnlyCollection<ulong>>(x);
+                    CreateSteamWebResponseMap<ResolveVanityUrlResultContainer, ulong>(x);
+                    CreateSteamWebResponseMap<GlobalAchievementPercentagesResultContainer, IReadOnlyCollection<GlobalAchievementPercentageModel>>(x);
+                    CreateSteamWebResponseMap<GlobalStatsForGameResultContainer, IReadOnlyCollection<GlobalStatModel>>(x);
+                    CreateSteamWebResponseMap<CurrentPlayersResultContainer, uint>(x);
+                    CreateSteamWebResponseMap<PlayerAchievementResultContainer, PlayerAchievementResultModel>(x);
+                    CreateSteamWebResponseMap<SchemaForGameResultContainer, SchemaForGameResultModel>(x);
+                    CreateSteamWebResponseMap<UserStatsForGameResultContainer, UserStatsForGameResultModel>(x);
+                    CreateSteamWebResponseMap<SteamServerInfo, SteamServerInfoModel>(x);
+                    CreateSteamWebResponseMap<SteamApiListContainer, IReadOnlyCollection<SteamInterfaceModel>>(x);
+                    CreateSteamWebResponseMap<GoldenWrenchResultContainer, IReadOnlyCollection<GoldenWrenchModel>>(x);
 
                     #region Endpoint: DOTA2Econ
 
                     x.CreateMap<Hero, HeroModel>();
-                    x.CreateMap<HeroResultContainer, IReadOnlyCollection<HeroModel>>().ConstructUsing(
+                    x.CreateMap<HeroResultContainer, IReadOnlyCollection<HeroModel>>().ConvertUsing(
                         src => Mapper.Map<IList<Hero>, IReadOnlyCollection<HeroModel>>(src.Result.Heroes)
                     );
 

--- a/SteamWebAPI2/Interfaces/CSGOServers.cs
+++ b/SteamWebAPI2/Interfaces/CSGOServers.cs
@@ -27,13 +27,13 @@ namespace SteamWebAPI2.Interfaces
         /// Maps to the Steam Web API interface/method of ICSGOServers_730/GetGameServersStatus/v1
         /// </summary>
         /// <returns></returns>
-        public async Task<ServerStatusModel> GetGameServerStatusAsync()
+        public async Task<ISteamWebResponse<ServerStatusModel>> GetGameServerStatusAsync()
         {
-            var gameServerStatus = await steamWebInterface.GetAsync<ServerStatusResultContainer>("GetGameServersStatus", 1);
+            var steamWebResponse = await steamWebInterface.GetAsync<ServerStatusResultContainer>("GetGameServersStatus", 1);
 
-            var gameServerStatusModel = AutoMapperConfiguration.Mapper.Map<ServerStatusResult, ServerStatusModel>(gameServerStatus.Result);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<ServerStatusResultContainer>, ISteamWebResponse<ServerStatusModel>>(steamWebResponse);
 
-            return gameServerStatusModel;
+            return steamWebResponseModel;
         }
     }
 }

--- a/SteamWebAPI2/Interfaces/DOTA2Econ.cs
+++ b/SteamWebAPI2/Interfaces/DOTA2Econ.cs
@@ -31,17 +31,17 @@ namespace SteamWebAPI2.Interfaces
         /// </summary>
         /// <param name="language"></param>
         /// <returns></returns>
-        public async Task<IReadOnlyCollection<GameItemModel>> GetGameItemsAsync(string language = "en_us")
+        public async Task<ISteamWebResponse<IReadOnlyCollection<GameItemModel>>> GetGameItemsAsync(string language = "en_us")
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
 
             parameters.AddIfHasValue(language, "language");
 
-            var gameItems = await steamWebInterface.GetAsync<GameItemResultContainer>("GetGameItems", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<GameItemResultContainer>("GetGameItems", 1, parameters);
 
-            var gameItemModels = AutoMapperConfiguration.Mapper.Map<IList<GameItem>, IReadOnlyCollection<GameItemModel>>(gameItems.Result.Items);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<GameItemResultContainer>, ISteamWebResponse<IReadOnlyCollection<GameItemModel>>>(steamWebResponse);
 
-            return gameItemModels;
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="language"></param>
         /// <param name="itemizedOnly"></param>
         /// <returns></returns>
-        public async Task<IReadOnlyCollection<HeroModel>> GetHeroesAsync(string language = "en_us", bool itemizedOnly = false)
+        public async Task<ISteamWebResponse<IReadOnlyCollection<HeroModel>>> GetHeroesAsync(string language = "en_us", bool itemizedOnly = false)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
 
@@ -59,11 +59,11 @@ namespace SteamWebAPI2.Interfaces
             parameters.AddIfHasValue(language, "language");
             parameters.AddIfHasValue(itemizedOnlyValue, "itemizedonly");
 
-            var heroes = await steamWebInterface.GetAsync<HeroResultContainer>("GetHeroes", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<HeroResultContainer>("GetHeroes", 1, parameters);
 
-            var heroModels = AutoMapperConfiguration.Mapper.Map<IList<Hero>, IReadOnlyCollection<HeroModel>>(heroes.Result.Heroes);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<HeroResultContainer>, ISteamWebResponse<IReadOnlyCollection<HeroModel>>>(steamWebResponse);
 
-            return heroModels;
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="iconName"></param>
         /// <param name="iconType"></param>
         /// <returns></returns>
-        public async Task<string> GetItemIconPathAsync(string iconName, string iconType = "")
+        public async Task<ISteamWebResponse<string>> GetItemIconPathAsync(string iconName, string iconType = "")
         {
             if (String.IsNullOrEmpty(iconName))
             {
@@ -84,8 +84,11 @@ namespace SteamWebAPI2.Interfaces
             parameters.AddIfHasValue(iconName, "iconname");
             parameters.AddIfHasValue(iconType, "icontype");
 
-            var itemIconPath = await steamWebInterface.GetAsync<ItemIconPathResultContainer>("GetItemIconPath", 1, parameters);
-            return itemIconPath.Result.Path;
+            var steamWebResponse = await steamWebInterface.GetAsync<ItemIconPathResultContainer>("GetItemIconPath", 1, parameters);
+
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<ItemIconPathResultContainer>, ISteamWebResponse<string>>(steamWebResponse);
+
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -93,25 +96,17 @@ namespace SteamWebAPI2.Interfaces
         /// </summary>
         /// <param name="language"></param>
         /// <returns></returns>
-        public async Task<IReadOnlyCollection<RarityModel>> GetRaritiesAsync(string language = "en_us")
+        public async Task<ISteamWebResponse<IReadOnlyCollection<RarityModel>>> GetRaritiesAsync(string language = "en_us")
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
 
             parameters.AddIfHasValue(language, "language");
 
-            var raritiesContainer = await steamWebInterface.GetAsync<RarityResultContainer>("GetRarities", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<RarityResultContainer>("GetRarities", 1, parameters);
 
-            var rarityModels = raritiesContainer.Result.Rarities.Select(x => new RarityModel()
-            {
-                Id = x.Id,
-                Name = x.Name,
-                Color = x.Color,
-                Order = x.Order
-            })
-            .ToList()
-            .AsReadOnly();
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<RarityResultContainer>, ISteamWebResponse<IReadOnlyCollection<RarityModel>>>(steamWebResponse);
 
-            return rarityModels;
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -119,14 +114,17 @@ namespace SteamWebAPI2.Interfaces
         /// </summary>
         /// <param name="leagueId"></param>
         /// <returns></returns>
-        public async Task<uint> GetTournamentPrizePoolAsync(uint? leagueId = null)
+        public async Task<ISteamWebResponse<uint>> GetTournamentPrizePoolAsync(uint? leagueId = null)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
 
             parameters.AddIfHasValue(leagueId, "leagueid");
 
-            var raritiesContainer = await steamWebInterface.GetAsync<PrizePoolResultContainer>("GetTournamentPrizePool", 1, parameters);
-            return raritiesContainer.Result.PrizePool;
+            var steamWebResponse = await steamWebInterface.GetAsync<PrizePoolResultContainer>("GetTournamentPrizePool", 1, parameters);
+
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<PrizePoolResultContainer>, ISteamWebResponse<uint>>(steamWebResponse);
+
+            return steamWebResponseModel;
         }
     }
 }

--- a/SteamWebAPI2/Interfaces/DOTA2Fantasy.cs
+++ b/SteamWebAPI2/Interfaces/DOTA2Fantasy.cs
@@ -44,9 +44,9 @@ namespace SteamWebAPI2.Interfaces
         /// <returns></returns>
         public async Task<ISteamWebResponse<ProPlayerDetailModel>> GetProPlayerList()
         {
-            var steamWebResponse = await steamWebInterface.GetAsync<ProPlayerListResultContainer>("GetProPlayerList", 1);
+            var steamWebResponse = await steamWebInterface.GetAsync<ProPlayerListResult>("GetProPlayerList", 1);
 
-            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<ProPlayerListResultContainer>, ISteamWebResponse<ProPlayerDetailModel>>(steamWebResponse);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<ProPlayerListResult>, ISteamWebResponse<ProPlayerDetailModel>>(steamWebResponse);
 
             return steamWebResponseModel;
         }

--- a/SteamWebAPI2/Interfaces/DOTA2Fantasy.cs
+++ b/SteamWebAPI2/Interfaces/DOTA2Fantasy.cs
@@ -26,36 +26,29 @@ namespace SteamWebAPI2.Interfaces
         /// </summary>
         /// <param name="steamId"></param>
         /// <returns></returns>
-        public async Task<PlayerOfficialInfoModel> GetPlayerOfficialInfo(ulong steamId)
+        public async Task<ISteamWebResponse<PlayerOfficialInfoModel>> GetPlayerOfficialInfo(ulong steamId)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
             parameters.Add(new SteamWebRequestParameter("accountid", steamId.ToString()));
 
-            var playerOfficialInfo = await steamWebInterface.GetAsync<PlayerOfficialInfoResultContainer>("GetPlayerOfficialInfo", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<PlayerOfficialInfoResultContainer>("GetPlayerOfficialInfo", 1, parameters);
 
-            var playerOfficialInfoModel = new PlayerOfficialInfoModel()
-            {
-                Name = playerOfficialInfo.Result.Name,
-                FantasyRole = playerOfficialInfo.Result.FantasyRole,
-                Sponsor = playerOfficialInfo.Result.Sponsor,
-                TeamName = playerOfficialInfo.Result.TeamName,
-                TeamTag = playerOfficialInfo.Result.TeamTag
-            };
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<PlayerOfficialInfoResultContainer>, ISteamWebResponse<PlayerOfficialInfoModel>>(steamWebResponse);
 
-            return playerOfficialInfoModel;
+            return steamWebResponseModel;
         }
 
         /// <summary>
         /// Returns a collection of all professional players registered in professional Dota 2 leagues.
         /// </summary>
         /// <returns></returns>
-        public async Task<ProPlayerDetailModel> GetProPlayerList()
+        public async Task<ISteamWebResponse<ProPlayerDetailModel>> GetProPlayerList()
         {
-            var proPlayerList = await steamWebInterface.GetAsync<ProPlayerListResultContainer>("GetProPlayerList", 1);
+            var steamWebResponse = await steamWebInterface.GetAsync<ProPlayerListResultContainer>("GetProPlayerList", 1);
 
-            var proPlayerDetailModel = AutoMapperConfiguration.Mapper.Map<ProPlayerListResult, ProPlayerDetailModel>(proPlayerList.Result);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<ProPlayerListResultContainer>, ISteamWebResponse<ProPlayerDetailModel>>(steamWebResponse);
 
-            return proPlayerDetailModel;
+            return steamWebResponseModel;
         }
     }
 }

--- a/SteamWebAPI2/Interfaces/DOTA2Match.cs
+++ b/SteamWebAPI2/Interfaces/DOTA2Match.cs
@@ -28,24 +28,17 @@ namespace SteamWebAPI2.Interfaces
         /// </summary>
         /// <param name="language"></param>
         /// <returns></returns>
-        public async Task<IReadOnlyCollection<LeagueModel>> GetLeagueListingAsync(string language = "en_us")
+        public async Task<ISteamWebResponse<IReadOnlyCollection<LeagueModel>>> GetLeagueListingAsync(string language = "en_us")
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
 
             parameters.AddIfHasValue(language, "language");
 
-            var leagueListing = await steamWebInterface.GetAsync<LeagueResultContainer>("GetLeagueListing", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<LeagueResultContainer>("GetLeagueListing", 1, parameters);
 
-            var leagueModels = leagueListing.Result.Leagues.Select(x => new LeagueModel()
-            {
-                Description = x.Description,
-                ItemDef = x.ItemDef,
-                LeagueId = x.LeagueId,
-                Name = x.Name,
-                TournamentUrl = x.TournamentUrl
-            }).ToList().AsReadOnly();
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<LeagueResultContainer>, ISteamWebResponse<IReadOnlyCollection<LeagueModel>>>(steamWebResponse);
 
-            return leagueModels;
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -54,18 +47,18 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="leagueId"></param>
         /// <param name="matchId"></param>
         /// <returns></returns>
-        public async Task<IReadOnlyCollection<LiveLeagueGameModel>> GetLiveLeagueGamesAsync(uint? leagueId = null, ulong? matchId = null)
+        public async Task<ISteamWebResponse<IReadOnlyCollection<LiveLeagueGameModel>>> GetLiveLeagueGamesAsync(uint? leagueId = null, ulong? matchId = null)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
 
             parameters.AddIfHasValue(leagueId, "league_id");
             parameters.AddIfHasValue(matchId, "match_id");
 
-            var liveLeagueGames = await steamWebInterface.GetAsync<LiveLeagueGameResultContainer>("GetLiveLeagueGames", 1);
+            var steamWebResponse = await steamWebInterface.GetAsync<LiveLeagueGameResultContainer>("GetLiveLeagueGames", 1);
 
-            var liveLeagueGamesModel = AutoMapperConfiguration.Mapper.Map<IList<LiveLeagueGame>, IList<LiveLeagueGameModel>>(liveLeagueGames.Result.Games);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<LiveLeagueGameResultContainer>, ISteamWebResponse<IReadOnlyCollection<LiveLeagueGameModel>>>(steamWebResponse);
 
-            return new ReadOnlyCollection<LiveLeagueGameModel>(liveLeagueGamesModel);
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -73,17 +66,17 @@ namespace SteamWebAPI2.Interfaces
         /// </summary>
         /// <param name="matchId"></param>
         /// <returns></returns>
-        public async Task<MatchDetailModel> GetMatchDetailsAsync(ulong matchId)
+        public async Task<ISteamWebResponse<MatchDetailModel>> GetMatchDetailsAsync(ulong matchId)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
 
             parameters.AddIfHasValue(matchId, "match_id");
 
-            var matchDetail = await steamWebInterface.GetAsync<MatchDetailResultContainer>("GetMatchDetails", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<MatchDetailResultContainer>("GetMatchDetails", 1, parameters);
 
-            var matchDetailModel = AutoMapperConfiguration.Mapper.Map<MatchDetailResult, MatchDetailModel>(matchDetail.Result);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<MatchDetailResultContainer>, ISteamWebResponse<MatchDetailModel>>(steamWebResponse);
 
-            return matchDetailModel;
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -99,7 +92,7 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="matchesRequested"></param>
         /// <param name="tournamentGamesOnly"></param>
         /// <returns></returns>
-        public async Task<MatchHistoryModel> GetMatchHistoryAsync(uint? heroId = null, uint? gameMode = null, uint? skill = null,
+        public async Task<ISteamWebResponse<MatchHistoryModel>> GetMatchHistoryAsync(uint? heroId = null, uint? gameMode = null, uint? skill = null,
             uint? minPlayers = null, ulong? accountId = null, uint? leagueId = null, ulong? startAtMatchId = null,
             string matchesRequested = "", string tournamentGamesOnly = "")
         {
@@ -115,11 +108,11 @@ namespace SteamWebAPI2.Interfaces
             parameters.AddIfHasValue(matchesRequested, "matches_requested");
             parameters.AddIfHasValue(tournamentGamesOnly, "tournament_games_only");
 
-            var matchHistory = await steamWebInterface.GetAsync<MatchHistoryResultContainer>("GetMatchHistory", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<MatchHistoryResultContainer>("GetMatchHistory", 1, parameters);
 
-            var matchHistoryModel = AutoMapperConfiguration.Mapper.Map<MatchHistoryResult, MatchHistoryModel>(matchHistory.Result);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<MatchHistoryResultContainer>, ISteamWebResponse<MatchHistoryModel>>(steamWebResponse);
 
-            return matchHistoryModel;
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -128,18 +121,20 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="startAtMatchSequenceNumber"></param>
         /// <param name="matchesRequested"></param>
         /// <returns></returns>
-        public async Task<IReadOnlyCollection<MatchHistoryMatchModel>> GetMatchHistoryBySequenceNumberAsync(ulong? startAtMatchSequenceNumber = null, uint? matchesRequested = null)
+        public async Task<ISteamWebResponse<IReadOnlyCollection<MatchHistoryMatchModel>>> GetMatchHistoryBySequenceNumberAsync(ulong? startAtMatchSequenceNumber = null, uint? matchesRequested = null)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
 
             parameters.AddIfHasValue(startAtMatchSequenceNumber, "start_at_match_seq_num");
             parameters.AddIfHasValue(matchesRequested, "matches_requested");
 
-            var matchHistory = await steamWebInterface.GetAsync<MatchHistoryBySequenceNumberResultContainer>("GetMatchHistoryBySequenceNum", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<MatchHistoryBySequenceNumberResultContainer>("GetMatchHistoryBySequenceNum", 1, parameters);
 
-            var matchHistoryModel = AutoMapperConfiguration.Mapper.Map<MatchHistoryBySequenceNumberResult, MatchHistoryModel>(matchHistory.Result);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<MatchHistoryBySequenceNumberResultContainer>,
+                ISteamWebResponse<IReadOnlyCollection<MatchHistoryMatchModel>>>(steamWebResponse);
 
-            return matchHistoryModel.Matches;
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -148,18 +143,18 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="startAtTeamId"></param>
         /// <param name="teamsRequested"></param>
         /// <returns></returns>
-        public async Task<IReadOnlyCollection<TeamInfoModel>> GetTeamInfoByTeamIdAsync(long? startAtTeamId = null, uint? teamsRequested = null)
+        public async Task<ISteamWebResponse<IReadOnlyCollection<TeamInfoModel>>> GetTeamInfoByTeamIdAsync(long? startAtTeamId = null, uint? teamsRequested = null)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
 
             parameters.AddIfHasValue(startAtTeamId, "start_at_team_id");
             parameters.AddIfHasValue(teamsRequested, "teams_requested");
 
-            var teamInfos = await steamWebInterface.GetAsync<TeamInfoResultContainer>("GetTeamInfoByTeamID", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<TeamInfoResultContainer>("GetTeamInfoByTeamID", 1, parameters);
 
-            var teamInfoModels = AutoMapperConfiguration.Mapper.Map<IList<TeamInfo>, IList<TeamInfoModel>>(teamInfos.Result.Teams);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<TeamInfoResultContainer>, ISteamWebResponse<IReadOnlyCollection<TeamInfoModel>>>(steamWebResponse);
 
-            return new ReadOnlyCollection<TeamInfoModel>(teamInfoModels);
+            return steamWebResponseModel;
         }
     }
 }

--- a/SteamWebAPI2/Interfaces/EconItems.cs
+++ b/SteamWebAPI2/Interfaces/EconItems.cs
@@ -72,17 +72,17 @@ namespace SteamWebAPI2.Interfaces
         /// </summary>
         /// <param name="steamId"></param>
         /// <returns></returns>
-        public async Task<EconItemResultModel> GetPlayerItemsAsync(ulong steamId)
+        public async Task<ISteamWebResponse<EconItemResultModel>> GetPlayerItemsAsync(ulong steamId)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
 
             parameters.AddIfHasValue(steamId, "steamid");
 
-            var econItemsResult = await steamWebInterface.GetAsync<EconItemResultContainer>("GetPlayerItems", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<EconItemResultContainer>("GetPlayerItems", 1, parameters);
 
-            var econItemResultModel = AutoMapperConfiguration.Mapper.Map<EconItemResult, EconItemResultModel>(econItemsResult.Result);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<EconItemResultContainer>, ISteamWebResponse<EconItemResultModel>>(steamWebResponse);
 
-            return econItemResultModel;
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace SteamWebAPI2.Interfaces
         /// </summary>
         /// <param name="language"></param>
         /// <returns></returns>
-        public async Task<Steam.Models.DOTA2.SchemaModel> GetSchemaAsync(string language = "en_us")
+        public async Task<ISteamWebResponse<Steam.Models.DOTA2.SchemaModel>> GetSchemaAsync(string language = "en_us")
         {
             if (!validSchemaAppIds.Contains(appId))
             {
@@ -101,19 +101,19 @@ namespace SteamWebAPI2.Interfaces
 
             parameters.AddIfHasValue(language, "language");
 
-            var schemaResult = await steamWebInterface.GetAsync<SchemaResultContainer>("GetSchema", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<SchemaResultContainer>("GetSchema", 1, parameters);
 
-            var schemaModel = AutoMapperConfiguration.Mapper.Map<SchemaResult, Steam.Models.DOTA2.SchemaModel>(schemaResult.Result);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<SchemaResultContainer>, ISteamWebResponse<Steam.Models.DOTA2.SchemaModel>>(steamWebResponse);
 
-            return schemaModel;
+            return steamWebResponseModel;
         }
 
         /// <summary>
-        /// Returns the economy / item schema for a specific App ID.
+        /// Returns the economy / item schema for TF2 specifically.
         /// </summary>
         /// <param name="language"></param>
         /// <returns></returns>
-        public async Task<Steam.Models.TF2.SchemaModel> GetSchemaForTF2Async(string language = "en_us")
+        public async Task<ISteamWebResponse<Steam.Models.TF2.SchemaModel>> GetSchemaForTF2Async(string language = "en_us")
         {
             if (this.appId != (int)EconItemsAppId.TeamFortress2)
             {
@@ -124,27 +124,29 @@ namespace SteamWebAPI2.Interfaces
 
             parameters.AddIfHasValue(language, "language");
 
-            var schemaResult = await steamWebInterface.GetAsync<SchemaResultContainer>("GetSchema", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<SchemaResultContainer>("GetSchema", 1, parameters);
 
-            var schemaModel = AutoMapperConfiguration.Mapper.Map<SchemaResult, Steam.Models.TF2.SchemaModel>(schemaResult.Result);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<SchemaResultContainer>, ISteamWebResponse<Steam.Models.TF2.SchemaModel>>(steamWebResponse);
 
-            return schemaModel;
+            return steamWebResponseModel;
         }
 
         /// <summary>
         /// Returns a URL which can be used to access the economy / item schema for a specific App ID.
         /// </summary>
         /// <returns></returns>
-        public async Task<string> GetSchemaUrlAsync()
+        public async Task<ISteamWebResponse<string>> GetSchemaUrlAsync()
         {
             if (!validSchemaUrlAppIds.Contains(appId))
             {
                 throw new InvalidOperationException(String.Format("AppId {0} is not valid for the GetSchemaUrl method.", appId));
             }
 
-            var schemaUrlResult = await steamWebInterface.GetAsync<SchemaUrlResultContainer>("GetSchemaURL", 1);
+            var steamWebResponse = await steamWebInterface.GetAsync<SchemaUrlResultContainer>("GetSchemaURL", 1);
 
-            return schemaUrlResult.Result.ItemsGameUrl;
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<SchemaUrlResultContainer>, ISteamWebResponse<string>>(steamWebResponse);
+
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -152,7 +154,7 @@ namespace SteamWebAPI2.Interfaces
         /// </summary>
         /// <param name="language"></param>
         /// <returns></returns>
-        public async Task<StoreMetaDataModel> GetStoreMetaDataAsync(string language = "")
+        public async Task<ISteamWebResponse<StoreMetaDataModel>> GetStoreMetaDataAsync(string language = "")
         {
             if (!validStoreMetaDataAppIds.Contains(appId))
             {
@@ -163,27 +165,29 @@ namespace SteamWebAPI2.Interfaces
 
             parameters.AddIfHasValue(language, "language");
 
-            var storeMetaDataResult = await steamWebInterface.GetAsync<StoreMetaDataResultContainer>("GetStoreMetaData", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<StoreMetaDataResultContainer>("GetStoreMetaData", 1, parameters);
 
-            var storeMetaDataModel = AutoMapperConfiguration.Mapper.Map<StoreMetaDataResult, StoreMetaDataModel>(storeMetaDataResult.Result);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<StoreMetaDataResultContainer>, ISteamWebResponse<StoreMetaDataModel>>(steamWebResponse);
 
-            return storeMetaDataModel;
+            return steamWebResponseModel;
         }
 
         /// <summary>
         /// Returns a status indicator of the current status of a specific App ID.
         /// </summary>
         /// <returns></returns>
-        public async Task<uint> GetStoreStatusAsync()
+        public async Task<ISteamWebResponse<uint>> GetStoreStatusAsync()
         {
             if (!validStoreStatusAppIds.Contains(appId))
             {
                 throw new InvalidOperationException(String.Format("AppId {0} is not valid for the GetStoreStatus method.", appId));
             }
 
-            var storeStatusResult = await steamWebInterface.GetAsync<StoreStatusResultContainer>("GetStoreStatus", 1);
+            var steamWebResponse = await steamWebInterface.GetAsync<StoreStatusResultContainer>("GetStoreStatus", 1);
 
-            return storeStatusResult.Result.StoreStatus;
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<StoreStatusResultContainer>, ISteamWebResponse<uint>>(steamWebResponse);
+
+            return steamWebResponseModel;
         }
     }
 }

--- a/SteamWebAPI2/Interfaces/EconService.cs
+++ b/SteamWebAPI2/Interfaces/EconService.cs
@@ -47,7 +47,9 @@ namespace SteamWebAPI2.Interfaces
 
             var steamWebResponse = await steamWebInterface.GetAsync<TradeHistoryResultContainer>("GetTradeHistory", 1, parameters);
 
-            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<TradeHistoryResultContainer>, ISteamWebResponse<Steam.Models.SteamEconomy.TradeHistoryModel>>(steamWebResponse);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<TradeHistoryResultContainer>, 
+                ISteamWebResponse<Steam.Models.SteamEconomy.TradeHistoryModel>>(steamWebResponse);
 
             return steamWebResponseModel;
         }
@@ -80,7 +82,9 @@ namespace SteamWebAPI2.Interfaces
 
             var steamWebResponse = await steamWebInterface.GetAsync<TradeOffersResultContainer>("GetTradeOffers", 1, parameters);
 
-            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<TradeOffersResultContainer>, ISteamWebResponse<Steam.Models.SteamEconomy.TradeOffersResultModel>>(steamWebResponse);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<TradeOffersResultContainer>, 
+                ISteamWebResponse<Steam.Models.SteamEconomy.TradeOffersResultModel>>(steamWebResponse);
 
             return steamWebResponseModel;
         }
@@ -100,7 +104,9 @@ namespace SteamWebAPI2.Interfaces
 
             var steamWebResponse = await steamWebInterface.GetAsync<TradeOfferResultContainer>("GetTradeOffer", 1, parameters);
 
-            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<TradeOfferResultContainer>, ISteamWebResponse<Steam.Models.SteamEconomy.TradeOfferResultModel>>(steamWebResponse);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<TradeOfferResultContainer>, 
+                ISteamWebResponse<Steam.Models.SteamEconomy.TradeOfferResultModel>>(steamWebResponse);
 
             return steamWebResponseModel;
         }

--- a/SteamWebAPI2/Interfaces/EconService.cs
+++ b/SteamWebAPI2/Interfaces/EconService.cs
@@ -32,7 +32,7 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="includeFailed">If set, trades in status k_ETradeStatus_Failed, k_ETradeStatus_RollbackFailed, k_ETradeStatus_RollbackAbandoned, and k_ETradeStatus_EscrowRollback will be included</param>
         /// <param name="includeTotal">Unknown</param>
         /// <returns></returns>
-        public async Task<Steam.Models.SteamEconomy.TradeHistoryModel> GetTradeHistory(uint maxTrades, uint startAfterTime = 0, ulong startAfterTradeId = 0, bool navigatingBack = false, bool getDescriptions = false, string language = "", bool includeFailed = false, bool includeTotal = false)
+        public async Task<ISteamWebResponse<Steam.Models.SteamEconomy.TradeHistoryModel>> GetTradeHistoryAsync(uint maxTrades, uint startAfterTime = 0, ulong startAfterTradeId = 0, bool navigatingBack = false, bool getDescriptions = false, string language = "", bool includeFailed = false, bool includeTotal = false)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
 
@@ -45,11 +45,11 @@ namespace SteamWebAPI2.Interfaces
             parameters.AddIfHasValue(includeFailed, "include_failed");
             parameters.AddIfHasValue(includeTotal, "inclue_total");
 
-            var tradeHistoryResult = await steamWebInterface.GetAsync<TradeHistoryResultContainer>("GetTradeHistory", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<TradeHistoryResultContainer>("GetTradeHistory", 1, parameters);
 
-            var tradeHistoryModel = AutoMapperConfiguration.Mapper.Map<TradeHistoryResult, Steam.Models.SteamEconomy.TradeHistoryModel>(tradeHistoryResult.Result);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<TradeHistoryResultContainer>, ISteamWebResponse<Steam.Models.SteamEconomy.TradeHistoryModel>>(steamWebResponse);
 
-            return tradeHistoryModel;
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="historicalOnly">Return trade offers that are not in an active state.</param>
         /// <param name="timeHistoricalCutoff">A unix time value. when active_only is set, inactive offers will be returned if their state was updated since this time. Useful to get delta updates on what has changed. WARNING: If not passed, this will default to the time your account last viewed the trade offers page. To avoid this behavior use a very low or very high date.</param>
         /// <returns></returns>
-        public async Task<Steam.Models.SteamEconomy.TradeOffersResultModel> GetTradeOffers(bool getSentOffers, bool getReceivedOffers, bool getDescriptions = false, string language = "", bool activeOnly = false, bool historicalOnly = false, uint timeHistoricalCutoff = 0)
+        public async Task<ISteamWebResponse<Steam.Models.SteamEconomy.TradeOffersResultModel>> GetTradeOffersAsync(bool getSentOffers, bool getReceivedOffers, bool getDescriptions = false, string language = "", bool activeOnly = false, bool historicalOnly = false, uint timeHistoricalCutoff = 0)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
 
@@ -78,11 +78,11 @@ namespace SteamWebAPI2.Interfaces
             parameters.AddIfHasValue(historicalOnly, "historicalOnly");
             parameters.AddIfHasValue(timeHistoricalCutoff, "time_historical_cutoff");
 
-            var tradeOffersResult = await steamWebInterface.GetAsync<TradeOffersResultContainer>("GetTradeOffers", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<TradeOffersResultContainer>("GetTradeOffers", 1, parameters);
 
-            var tradeOffersModel = AutoMapperConfiguration.Mapper.Map<TradeOffersResult, Steam.Models.SteamEconomy.TradeOffersResultModel>(tradeOffersResult.Result);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<TradeOffersResultContainer>, ISteamWebResponse<Steam.Models.SteamEconomy.TradeOffersResultModel>>(steamWebResponse);
 
-            return tradeOffersModel;
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -91,18 +91,18 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="tradeOfferId">The trade offer identifier</param>
         /// <param name="language">The language to use for item display information.</param>
         /// <returns></returns>
-        public async Task<Steam.Models.SteamEconomy.TradeOfferResultModel> GetTradeOffer(ulong tradeOfferId, string language = "")
+        public async Task<ISteamWebResponse<Steam.Models.SteamEconomy.TradeOfferResultModel>> GetTradeOfferAsync(ulong tradeOfferId, string language = "")
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
 
             parameters.AddIfHasValue(tradeOfferId, "tradeOfferId");
             parameters.AddIfHasValue(language, "language");
 
-            var tradeOfferResult = await steamWebInterface.GetAsync<TradeOfferResultContainer>("GetTradeOffer", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<TradeOfferResultContainer>("GetTradeOffer", 1, parameters);
 
-            var tradeOfferModel = AutoMapperConfiguration.Mapper.Map<TradeOfferResult, Steam.Models.SteamEconomy.TradeOfferResultModel>(tradeOfferResult.Result);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<TradeOfferResultContainer>, ISteamWebResponse<Steam.Models.SteamEconomy.TradeOfferResultModel>>(steamWebResponse);
 
-            return tradeOfferModel;
+            return steamWebResponseModel;
         }
     }
 }

--- a/SteamWebAPI2/Interfaces/GCVersion.cs
+++ b/SteamWebAPI2/Interfaces/GCVersion.cs
@@ -55,36 +55,36 @@ namespace SteamWebAPI2.Interfaces
         /// Returns the most recent client version number based on a specific App ID.
         /// </summary>
         /// <returns></returns>
-        public async Task<GameClientResultModel> GetClientVersionAsync()
+        public async Task<ISteamWebResponse<GameClientResultModel>> GetClientVersionAsync()
         {
             if (!validClientVersionAppIds.Contains(appId))
             {
                 throw new InvalidOperationException(String.Format("AppId {0} is not valid for the GetClientVersion method.", appId));
             }
 
-            var clientVersion = await steamWebInterface.GetAsync<GameClientResultContainer>("GetClientVersion", 1);
+            var steamWebResponse = await steamWebInterface.GetAsync<GameClientResultContainer>("GetClientVersion", 1);
 
-            var clientVersionModel = AutoMapperConfiguration.Mapper.Map<GameClientResult, GameClientResultModel>(clientVersion.Result);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<GameClientResultContainer>, ISteamWebResponse<GameClientResultModel>>(steamWebResponse);
 
-            return clientVersionModel;
+            return steamWebResponseModel;
         }
 
         /// <summary>
         /// Returns the most recent server version number based on a specific App ID.
         /// </summary>
         /// <returns></returns>
-        public async Task<GameClientResultModel> GetServerVersionAsync()
+        public async Task<ISteamWebResponse<GameClientResultModel>> GetServerVersionAsync()
         {
             if (!validServerVersionAppIds.Contains(appId))
             {
                 throw new InvalidOperationException(String.Format("AppId {0} is not valid for the GetServerVersion method.", appId));
             }
 
-            var serverVersion = await steamWebInterface.GetAsync<GameClientResultContainer>("GetServerVersion", 1);
+            var steamWebResponse = await steamWebInterface.GetAsync<GameClientResultContainer>("GetServerVersion", 1);
 
-            var serverVersionModel = AutoMapperConfiguration.Mapper.Map<GameClientResult, GameClientResultModel>(serverVersion.Result);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<GameClientResultContainer>, ISteamWebResponse<GameClientResultModel>>(steamWebResponse);
 
-            return serverVersionModel;
+            return steamWebResponseModel;
         }
     }
 }

--- a/SteamWebAPI2/Interfaces/GameServersService.cs
+++ b/SteamWebAPI2/Interfaces/GameServersService.cs
@@ -19,76 +19,76 @@ namespace SteamWebAPI2.Interfaces
                 : steamWebInterface;
         }
 
-        public async Task<dynamic> GetAccountListAsync()
+        public async Task<ISteamWebResponse<dynamic>> GetAccountListAsync()
         {
-            var accountList = await steamWebInterface.GetAsync<dynamic>("GetAccountList", 1);
-            return accountList;
+            var steamWebResponse = await steamWebInterface.GetAsync<dynamic>("GetsteamWebResponse", 1);
+            return steamWebResponse;
         }
 
-        public async Task<dynamic> CreateAccount(uint appId, string memo)
+        public async Task<ISteamWebResponse<dynamic>> CreateAccount(uint appId, string memo)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
             parameters.AddIfHasValue(appId, "appid");
             parameters.AddIfHasValue(memo, "memo");
-            var accountList = await steamWebInterface.PostAsync<dynamic>("CreateAccount", 1, parameters);
-            return accountList;
+            var steamWebResponse = await steamWebInterface.PostAsync<dynamic>("CreateAccount", 1, parameters);
+            return steamWebResponse;
         }
 
-        public async Task<dynamic> SetMemo(ulong steamId, string memo)
+        public async Task<ISteamWebResponse<dynamic>> SetMemo(ulong steamId, string memo)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
             parameters.AddIfHasValue(steamId, "steamid");
             parameters.AddIfHasValue(memo, "memo");
-            var accountList = await steamWebInterface.PostAsync<dynamic>("SetMemo", 1, parameters);
-            return accountList;
+            var steamWebResponse = await steamWebInterface.PostAsync<dynamic>("SetMemo", 1, parameters);
+            return steamWebResponse;
         }
 
-        public async Task<dynamic> ResetLoginToken(ulong steamId)
+        public async Task<ISteamWebResponse<dynamic>> ResetLoginToken(ulong steamId)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
             parameters.AddIfHasValue(steamId, "steamid");
-            var accountList = await steamWebInterface.PostAsync<dynamic>("ResetLoginToken", 1, parameters);
-            return accountList;
+            var steamWebResponse = await steamWebInterface.PostAsync<dynamic>("ResetLoginToken", 1, parameters);
+            return steamWebResponse;
         }
 
-        public async Task<dynamic> DeleteAccount(ulong steamId)
+        public async Task<ISteamWebResponse<dynamic>> DeleteAccount(ulong steamId)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
             parameters.AddIfHasValue(steamId, "steamid");
-            var accountList = await steamWebInterface.PostAsync<dynamic>("DeleteAccount", 1, parameters);
-            return accountList;
+            var steamWebResponse = await steamWebInterface.PostAsync<dynamic>("DeleteAccount", 1, parameters);
+            return steamWebResponse;
         }
 
-        public async Task<dynamic> GetAccountPublicInfo(ulong steamId)
+        public async Task<ISteamWebResponse<dynamic>> GetAccountPublicInfo(ulong steamId)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
             parameters.AddIfHasValue(steamId, "steamid");
-            var accountList = await steamWebInterface.GetAsync<dynamic>("GetAccountPublicInfo", 1, parameters);
-            return accountList;
+            var steamWebResponse = await steamWebInterface.GetAsync<dynamic>("GetAccountPublicInfo", 1, parameters);
+            return steamWebResponse;
         }
 
-        public async Task<dynamic> QueryLoginToken(string loginToken)
+        public async Task<ISteamWebResponse<dynamic>> QueryLoginToken(string loginToken)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
             parameters.AddIfHasValue(loginToken, "login_token");
-            var accountList = await steamWebInterface.GetAsync<dynamic>("QueryLoginToken", 1, parameters);
-            return accountList;
+            var steamWebResponse = await steamWebInterface.GetAsync<dynamic>("QueryLoginToken", 1, parameters);
+            return steamWebResponse;
         }
 
-        public async Task<dynamic> GetServerSteamIDsByIP(IReadOnlyCollection<string> serverIPs)
+        public async Task<ISteamWebResponse<dynamic>> GetServerSteamIDsByIP(IReadOnlyCollection<string> serverIPs)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
             parameters.AddIfHasValue(serverIPs, "server_ips");
-            var accountList = await steamWebInterface.GetAsync<dynamic>("GetServerSteamIDsByIP", 1, parameters);
-            return accountList;
+            var steamWebResponse = await steamWebInterface.GetAsync<dynamic>("GetServerSteamIDsByIP", 1, parameters);
+            return steamWebResponse;
         }
 
-        public async Task<dynamic> GetServerIPsBySteamID(IReadOnlyCollection<ulong> steamIds)
+        public async Task<ISteamWebResponse<dynamic>> GetServerIPsBySteamID(IReadOnlyCollection<ulong> steamIds)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
             parameters.AddIfHasValue(steamIds, "server_steamids");
-            var accountList = await steamWebInterface.GetAsync<dynamic>("GetServerIPsBySteamID", 1, parameters);
-            return accountList;
+            var steamWebResponse = await steamWebInterface.GetAsync<dynamic>("GetServerIPsBySteamID", 1, parameters);
+            return steamWebResponse;
         }
     }
 }

--- a/SteamWebAPI2/Interfaces/GameServersService.cs
+++ b/SteamWebAPI2/Interfaces/GameServersService.cs
@@ -21,7 +21,7 @@ namespace SteamWebAPI2.Interfaces
 
         public async Task<ISteamWebResponse<dynamic>> GetAccountListAsync()
         {
-            var steamWebResponse = await steamWebInterface.GetAsync<dynamic>("GetsteamWebResponse", 1);
+            var steamWebResponse = await steamWebInterface.GetAsync<dynamic>("GetAccountList", 1);
             return steamWebResponse;
         }
 

--- a/SteamWebAPI2/Interfaces/ICSGOServers.cs
+++ b/SteamWebAPI2/Interfaces/ICSGOServers.cs
@@ -1,10 +1,11 @@
 ﻿using Steam.Models.CSGO;
+using SteamWebAPI2.Utilities;
 using System.Threading.Tasks;
 
 namespace SteamWebAPI2.Interfaces
 {
     public interface ICSGOServers
     {
-        Task<ServerStatusModel> GetGameServerStatusAsync();
+        Task<ISteamWebResponse<ServerStatusModel>> GetGameServerStatusAsync();
     }
 }

--- a/SteamWebAPI2/Interfaces/IDOTA2Econ.cs
+++ b/SteamWebAPI2/Interfaces/IDOTA2Econ.cs
@@ -1,4 +1,5 @@
 ﻿using Steam.Models.DOTA2;
+using SteamWebAPI2.Utilities;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -6,14 +7,14 @@ namespace SteamWebAPI2.Interfaces
 {
     public interface IDOTA2Econ
     {
-        Task<IReadOnlyCollection<GameItemModel>> GetGameItemsAsync(string language = "");
+        Task<ISteamWebResponse<IReadOnlyCollection<GameItemModel>>> GetGameItemsAsync(string language = "");
 
-        Task<IReadOnlyCollection<HeroModel>> GetHeroesAsync(string language = "", bool itemizedOnly = false);
+        Task<ISteamWebResponse<IReadOnlyCollection<HeroModel>>> GetHeroesAsync(string language = "", bool itemizedOnly = false);
 
-        Task<string> GetItemIconPathAsync(string iconName, string iconType = "");
+        Task<ISteamWebResponse<string>> GetItemIconPathAsync(string iconName, string iconType = "");
 
-        Task<IReadOnlyCollection<RarityModel>> GetRaritiesAsync(string language = "");
+        Task<ISteamWebResponse<IReadOnlyCollection<RarityModel>>> GetRaritiesAsync(string language = "");
 
-        Task<uint> GetTournamentPrizePoolAsync(uint? leagueId = null);
+        Task<ISteamWebResponse<uint>> GetTournamentPrizePoolAsync(uint? leagueId = null);
     }
 }

--- a/SteamWebAPI2/Interfaces/IDOTA2Fantasy.cs
+++ b/SteamWebAPI2/Interfaces/IDOTA2Fantasy.cs
@@ -1,12 +1,13 @@
 ﻿using Steam.Models.DOTA2;
+using SteamWebAPI2.Utilities;
 using System.Threading.Tasks;
 
 namespace SteamWebAPI2.Interfaces
 {
     public interface IDOTA2Fantasy
     {
-        Task<PlayerOfficialInfoModel> GetPlayerOfficialInfo(ulong steamId);
+        Task<ISteamWebResponse<PlayerOfficialInfoModel>> GetPlayerOfficialInfo(ulong steamId);
 
-        Task<ProPlayerDetailModel> GetProPlayerList();
+        Task<ISteamWebResponse<ProPlayerDetailModel>> GetProPlayerList();
     }
 }

--- a/SteamWebAPI2/Interfaces/IDOTA2Match.cs
+++ b/SteamWebAPI2/Interfaces/IDOTA2Match.cs
@@ -1,4 +1,5 @@
 ﻿using Steam.Models.DOTA2;
+using SteamWebAPI2.Utilities;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -6,16 +7,16 @@ namespace SteamWebAPI2.Interfaces
 {
     public interface IDOTA2Match
     {
-        Task<IReadOnlyCollection<LeagueModel>> GetLeagueListingAsync(string language);
+        Task<ISteamWebResponse<IReadOnlyCollection<LeagueModel>>> GetLeagueListingAsync(string language);
 
-        Task<IReadOnlyCollection<LiveLeagueGameModel>> GetLiveLeagueGamesAsync(uint? leagueId = null, ulong? matchId = null);
+        Task<ISteamWebResponse<IReadOnlyCollection<LiveLeagueGameModel>>> GetLiveLeagueGamesAsync(uint? leagueId = null, ulong? matchId = null);
 
-        Task<MatchDetailModel> GetMatchDetailsAsync(ulong matchId);
+        Task<ISteamWebResponse<MatchDetailModel>> GetMatchDetailsAsync(ulong matchId);
 
-        Task<MatchHistoryModel> GetMatchHistoryAsync(uint? heroId = null, uint? gameMode = null, uint? skill = null, uint? minPlayers = null, ulong? accountId = null, uint? leagueId = null, ulong? startAtMatchId = null, string matchesRequested = "", string tournamentGamesOnly = "");
+        Task<ISteamWebResponse<MatchHistoryModel>> GetMatchHistoryAsync(uint? heroId = null, uint? gameMode = null, uint? skill = null, uint? minPlayers = null, ulong? accountId = null, uint? leagueId = null, ulong? startAtMatchId = null, string matchesRequested = "", string tournamentGamesOnly = "");
 
-        Task<IReadOnlyCollection<MatchHistoryMatchModel>> GetMatchHistoryBySequenceNumberAsync(ulong? startAtMatchSequenceNumber = null, uint? matchesRequested = null);
+        Task<ISteamWebResponse<IReadOnlyCollection<MatchHistoryMatchModel>>> GetMatchHistoryBySequenceNumberAsync(ulong? startAtMatchSequenceNumber = null, uint? matchesRequested = null);
 
-        Task<IReadOnlyCollection<TeamInfoModel>> GetTeamInfoByTeamIdAsync(long? startAtTeamId = default(long?), uint? teamsRequested = null);
+        Task<ISteamWebResponse<IReadOnlyCollection<TeamInfoModel>>> GetTeamInfoByTeamIdAsync(long? startAtTeamId = default(long?), uint? teamsRequested = null);
     }
 }

--- a/SteamWebAPI2/Interfaces/IEconItems.cs
+++ b/SteamWebAPI2/Interfaces/IEconItems.cs
@@ -1,19 +1,20 @@
 ﻿using Steam.Models.DOTA2;
 using Steam.Models.GameEconomy;
+using SteamWebAPI2.Utilities;
 using System.Threading.Tasks;
 
 namespace SteamWebAPI2.Interfaces
 {
     public interface IEconItems
     {
-        Task<EconItemResultModel> GetPlayerItemsAsync(ulong steamId);
+        Task<ISteamWebResponse<EconItemResultModel>> GetPlayerItemsAsync(ulong steamId);
 
-        Task<SchemaModel> GetSchemaAsync(string language = "");
+        Task<ISteamWebResponse<SchemaModel>> GetSchemaAsync(string language = "");
 
-        Task<string> GetSchemaUrlAsync();
+        Task<ISteamWebResponse<string>> GetSchemaUrlAsync();
 
-        Task<StoreMetaDataModel> GetStoreMetaDataAsync(string language = "");
+        Task<ISteamWebResponse<StoreMetaDataModel>> GetStoreMetaDataAsync(string language = "");
 
-        Task<uint> GetStoreStatusAsync();
+        Task<ISteamWebResponse<uint>> GetStoreStatusAsync();
     }
 }

--- a/SteamWebAPI2/Interfaces/IEconService.cs
+++ b/SteamWebAPI2/Interfaces/IEconService.cs
@@ -1,4 +1,5 @@
 ﻿using Steam.Models.SteamEconomy;
+using SteamWebAPI2.Utilities;
 using System.Threading.Tasks;
 
 namespace SteamWebAPI2.Interfaces
@@ -17,7 +18,7 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="includeFailed">If set, trades in status k_ETradeStatus_Failed, k_ETradeStatus_RollbackFailed, k_ETradeStatus_RollbackAbandoned, and k_ETradeStatus_EscrowRollback will be included</param>
         /// <param name="includeTotal">Unknown</param>
         /// <returns></returns>
-        Task<TradeHistoryModel> GetTradeHistory(uint maxTrades, uint startAfterTime, ulong startAfterTradeId, bool navigatingBack, bool getDescriptions, string language, bool includeFailed, bool includeTotal);
+        Task<ISteamWebResponse<TradeHistoryModel>> GetTradeHistoryAsync(uint maxTrades, uint startAfterTime, ulong startAfterTradeId, bool navigatingBack, bool getDescriptions, string language, bool includeFailed, bool includeTotal);
 
         /// <summary>
         /// This API gets a list of trade offers (up to a maximum of 500 sent or 1000 received regardless of time_historical_cutoff) for the account associated with the WebAPI key. You cannot call this API for accounts other than your own.
@@ -30,7 +31,7 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="historicalOnly">Return trade offers that are not in an active state.</param>
         /// <param name="timeHistoricalCutoff">A unix time value. when active_only is set, inactive offers will be returned if their state was updated since this time. Useful to get delta updates on what has changed. WARNING: If not passed, this will default to the time your account last viewed the trade offers page. To avoid this behavior use a very low or very high date.</param>
         /// <returns></returns>
-        Task<TradeOffersResultModel> GetTradeOffers(bool getSentOffers, bool getReceivedOffers, bool getDescriptions, string language, bool activeOnly, bool historicalOnly, uint timeHistoricalCutoff);
+        Task<ISteamWebResponse<TradeOffersResultModel>> GetTradeOffersAsync(bool getSentOffers, bool getReceivedOffers, bool getDescriptions, string language, bool activeOnly, bool historicalOnly, uint timeHistoricalCutoff);
 
         /// <summary>
         /// This API gets details about a single trade offer. The trade offer must have been sent to or from the account associated with the WebAPI key. You cannot call this API for accounts other than your own.
@@ -38,7 +39,7 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="tradeOfferId">The trade offer identifier</param>
         /// <param name="language">The language to use for item display information.</param>
         /// <returns></returns>
-        Task<TradeOfferResultModel> GetTradeOffer(ulong tradeOfferId, string language);
+        Task<ISteamWebResponse<TradeOfferResultModel>> GetTradeOfferAsync(ulong tradeOfferId, string language);
 
         //Task GetTradeOffersSummary(ulong timeLastVisit);
         //Task DeclineTradeOffer(ulong tradeOfferId);

--- a/SteamWebAPI2/Interfaces/IGCVersion.cs
+++ b/SteamWebAPI2/Interfaces/IGCVersion.cs
@@ -1,12 +1,13 @@
 ﻿using Steam.Models;
+using SteamWebAPI2.Utilities;
 using System.Threading.Tasks;
 
 namespace SteamWebAPI2.Interfaces
 {
     public interface IGCVersion
     {
-        Task<GameClientResultModel> GetClientVersionAsync();
+        Task<ISteamWebResponse<GameClientResultModel>> GetClientVersionAsync();
 
-        Task<GameClientResultModel> GetServerVersionAsync();
+        Task<ISteamWebResponse<GameClientResultModel>> GetServerVersionAsync();
     }
 }

--- a/SteamWebAPI2/Interfaces/IGameServersService.cs
+++ b/SteamWebAPI2/Interfaces/IGameServersService.cs
@@ -1,26 +1,27 @@
-﻿using System.Collections.Generic;
+﻿using SteamWebAPI2.Utilities;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace SteamWebAPI2.Interfaces
 {
     public interface IGameServersService
     {
-        Task<dynamic> GetAccountListAsync();
+        Task<ISteamWebResponse<dynamic>> GetAccountListAsync();
 
-        Task<dynamic> CreateAccount(uint appid, string memo);
+        Task<ISteamWebResponse<dynamic>> CreateAccount(uint appid, string memo);
 
-        Task<dynamic> SetMemo(ulong steamId, string memo);
+        Task<ISteamWebResponse<dynamic>> SetMemo(ulong steamId, string memo);
 
-        Task<dynamic> ResetLoginToken(ulong steamId);
+        Task<ISteamWebResponse<dynamic>> ResetLoginToken(ulong steamId);
 
-        Task<dynamic> DeleteAccount(ulong steamId);
+        Task<ISteamWebResponse<dynamic>> DeleteAccount(ulong steamId);
 
-        Task<dynamic> GetAccountPublicInfo(ulong steamId);
+        Task<ISteamWebResponse<dynamic>> GetAccountPublicInfo(ulong steamId);
 
-        Task<dynamic> QueryLoginToken(string loginToken);
+        Task<ISteamWebResponse<dynamic>> QueryLoginToken(string loginToken);
 
-        Task<dynamic> GetServerSteamIDsByIP(IReadOnlyCollection<string> serverIPs);
+        Task<ISteamWebResponse<dynamic>> GetServerSteamIDsByIP(IReadOnlyCollection<string> serverIPs);
 
-        Task<dynamic> GetServerIPsBySteamID(IReadOnlyCollection<ulong> steamIds);
+        Task<ISteamWebResponse<dynamic>> GetServerIPsBySteamID(IReadOnlyCollection<ulong> steamIds);
     }
 }

--- a/SteamWebAPI2/Interfaces/IPlayerService.cs
+++ b/SteamWebAPI2/Interfaces/IPlayerService.cs
@@ -1,4 +1,5 @@
 ﻿using Steam.Models.SteamCommunity;
+using SteamWebAPI2.Utilities;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -6,16 +7,16 @@ namespace SteamWebAPI2.Interfaces
 {
     public interface IPlayerService
     {
-        Task<BadgesResultModel> GetBadgesAsync(ulong steamId);
+        Task<ISteamWebResponse<BadgesResultModel>> GetBadgesAsync(ulong steamId);
 
-        Task<IReadOnlyCollection<BadgeQuestModel>> GetCommunityBadgeProgressAsync(ulong steamId, uint? badgeId = null);
+        Task<ISteamWebResponse<IReadOnlyCollection<BadgeQuestModel>>> GetCommunityBadgeProgressAsync(ulong steamId, uint? badgeId = null);
 
-        Task<OwnedGamesResultModel> GetOwnedGamesAsync(ulong steamId, bool? includeAppInfo = null, bool? includeFreeGames = null, IReadOnlyCollection<uint> appIdsToFilter = null);
+        Task<ISteamWebResponse<OwnedGamesResultModel>> GetOwnedGamesAsync(ulong steamId, bool? includeAppInfo = null, bool? includeFreeGames = null, IReadOnlyCollection<uint> appIdsToFilter = null);
 
-        Task<RecentlyPlayedGamesResultModel> GetRecentlyPlayedGamesAsync(ulong steamId);
+        Task<ISteamWebResponse<RecentlyPlayedGamesResultModel>> GetRecentlyPlayedGamesAsync(ulong steamId);
 
-        Task<uint?> GetSteamLevelAsync(ulong steamId);
+        Task<ISteamWebResponse<uint?>> GetSteamLevelAsync(ulong steamId);
 
-        Task<ulong?> IsPlayingSharedGameAsync(ulong steamId, uint appId);
+        Task<ISteamWebResponse<ulong?>> IsPlayingSharedGameAsync(ulong steamId, uint appId);
     }
 }

--- a/SteamWebAPI2/Interfaces/ISteamApps.cs
+++ b/SteamWebAPI2/Interfaces/ISteamApps.cs
@@ -1,4 +1,5 @@
 ﻿using Steam.Models;
+using SteamWebAPI2.Utilities;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -6,8 +7,8 @@ namespace SteamWebAPI2.Interfaces
 {
     public interface ISteamApps
     {
-        Task<IReadOnlyCollection<SteamAppModel>> GetAppListAsync();
+        Task<ISteamWebResponse<IReadOnlyCollection<SteamAppModel>>> GetAppListAsync();
 
-        Task<SteamAppUpToDateCheckModel> UpToDateCheckAsync(uint appId, uint version);
+        Task<ISteamWebResponse<SteamAppUpToDateCheckModel>> UpToDateCheckAsync(uint appId, uint version);
     }
 }

--- a/SteamWebAPI2/Interfaces/ISteamEconomy.cs
+++ b/SteamWebAPI2/Interfaces/ISteamEconomy.cs
@@ -1,4 +1,5 @@
 ﻿using Steam.Models.SteamEconomy;
+using SteamWebAPI2.Utilities;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -6,8 +7,8 @@ namespace SteamWebAPI2.Interfaces
 {
     public interface ISteamEconomy
     {
-        Task<AssetClassInfoResultModel> GetAssetClassInfoAsync(uint appId, IReadOnlyList<ulong> classIds, string language);
+        Task<ISteamWebResponse<AssetClassInfoResultModel>> GetAssetClassInfoAsync(uint appId, IReadOnlyList<ulong> classIds, string language);
 
-        Task<AssetPriceResultModel> GetAssetPricesAsync(uint appId, string currency, string language);
+        Task<ISteamWebResponse<AssetPriceResultModel>> GetAssetPricesAsync(uint appId, string currency, string language);
     }
 }

--- a/SteamWebAPI2/Interfaces/ISteamNews.cs
+++ b/SteamWebAPI2/Interfaces/ISteamNews.cs
@@ -1,4 +1,5 @@
 ﻿using Steam.Models;
+using SteamWebAPI2.Utilities;
 using System;
 using System.Threading.Tasks;
 
@@ -6,6 +7,6 @@ namespace SteamWebAPI2.Interfaces
 {
     public interface ISteamNews
     {
-        Task<SteamNewsResultModel> GetNewsForAppAsync(uint appId, uint? maxLength = null, DateTime? endDate = null, uint? count = null);
+        Task<ISteamWebResponse<SteamNewsResultModel>> GetNewsForAppAsync(uint appId, uint? maxLength = null, DateTime? endDate = null, uint? count = null);
     }
 }

--- a/SteamWebAPI2/Interfaces/ISteamRemoteStorage.cs
+++ b/SteamWebAPI2/Interfaces/ISteamRemoteStorage.cs
@@ -1,10 +1,11 @@
 ﻿using Steam.Models;
+using SteamWebAPI2.Utilities;
 using System.Threading.Tasks;
 
 namespace SteamWebAPI2.Interfaces
 {
     public interface ISteamRemoteStorage
     {
-        Task<UGCFileDetailsModel> GetUGCFileDetailsAsync(ulong ugcId, uint appId, ulong? steamId = null);
+        Task<ISteamWebResponse<UGCFileDetailsModel>> GetUGCFileDetailsAsync(ulong ugcId, uint appId, ulong? steamId = null);
     }
 }

--- a/SteamWebAPI2/Interfaces/ISteamUser.cs
+++ b/SteamWebAPI2/Interfaces/ISteamUser.cs
@@ -1,4 +1,5 @@
 ﻿using Steam.Models.SteamCommunity;
+using SteamWebAPI2.Utilities;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -6,19 +7,19 @@ namespace SteamWebAPI2.Interfaces
 {
     public interface ISteamUser
     {
-        Task<IReadOnlyCollection<FriendModel>> GetFriendsListAsync(ulong steamId, string relationship = "");
+        Task<ISteamWebResponse<IReadOnlyCollection<FriendModel>>> GetFriendsListAsync(ulong steamId, string relationship = "");
 
-        Task<IReadOnlyCollection<PlayerBansModel>> GetPlayerBansAsync(ulong steamId);
+        Task<ISteamWebResponse<IReadOnlyCollection<PlayerBansModel>>> GetPlayerBansAsync(ulong steamId);
 
-        Task<IReadOnlyCollection<PlayerBansModel>> GetPlayerBansAsync(IReadOnlyCollection<ulong> steamIds);
+        Task<ISteamWebResponse<IReadOnlyCollection<PlayerBansModel>>> GetPlayerBansAsync(IReadOnlyCollection<ulong> steamIds);
 
-        Task<PlayerSummaryModel> GetPlayerSummaryAsync(ulong steamId);
+        Task<ISteamWebResponse<PlayerSummaryModel>> GetPlayerSummaryAsync(ulong steamId);
 
-        Task<List<PlayerSummaryModel>> GetPlayerSummariesAsync(IReadOnlyCollection<ulong> steamIds);
+        Task<ISteamWebResponse<IReadOnlyCollection<PlayerSummaryModel>>> GetPlayerSummariesAsync(IReadOnlyCollection<ulong> steamIds);
 
-        Task<IReadOnlyCollection<ulong>> GetUserGroupsAsync(ulong steamId);
+        Task<ISteamWebResponse<IReadOnlyCollection<ulong>>> GetUserGroupsAsync(ulong steamId);
 
-        Task<ulong> ResolveVanityUrlAsync(string vanityUrl, int? urlType = null);
+        Task<ISteamWebResponse<ulong>> ResolveVanityUrlAsync(string vanityUrl, int? urlType = null);
 
         Task<SteamCommunityProfileModel> GetCommunityProfileAsync(ulong steamId);
     }

--- a/SteamWebAPI2/Interfaces/ISteamUserAuth.cs
+++ b/SteamWebAPI2/Interfaces/ISteamUserAuth.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using SteamWebAPI2.Utilities;
+using System.Threading.Tasks;
 
 namespace SteamWebAPI2.Interfaces
 {
@@ -10,6 +11,6 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="appId">App ID of the game to authenticate against</param>
         /// <param name="ticket">Ticket from GetAuthSessionTicket</param>
         /// <returns>Results of authentication request</returns>
-        Task<dynamic> AuthenticateUserTicket(uint appId, string ticket);
+        Task<ISteamWebResponse<dynamic>> AuthenticateUserTicket(uint appId, string ticket);
     }
 }

--- a/SteamWebAPI2/Interfaces/ISteamUserStats.cs
+++ b/SteamWebAPI2/Interfaces/ISteamUserStats.cs
@@ -1,6 +1,7 @@
 ﻿using Steam.Models;
 using Steam.Models.SteamCommunity;
 using Steam.Models.SteamPlayer;
+using SteamWebAPI2.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -9,16 +10,16 @@ namespace SteamWebAPI2.Interfaces
 {
     public interface ISteamUserStats
     {
-        Task<IReadOnlyCollection<GlobalAchievementPercentageModel>> GetGlobalAchievementPercentagesForAppAsync(uint appId);
+        Task<ISteamWebResponse<IReadOnlyCollection<GlobalAchievementPercentageModel>>> GetGlobalAchievementPercentagesForAppAsync(uint appId);
 
-        Task<IReadOnlyCollection<GlobalStatModel>> GetGlobalStatsForGameAsync(uint appId, IReadOnlyList<string> statNames, DateTime? startDate = null, DateTime? endDate = null);
+        Task<ISteamWebResponse<IReadOnlyCollection<GlobalStatModel>>> GetGlobalStatsForGameAsync(uint appId, IReadOnlyList<string> statNames, DateTime? startDate = null, DateTime? endDate = null);
 
-        Task<uint> GetNumberOfCurrentPlayersForGameAsync(uint appId);
+        Task<ISteamWebResponse<uint>> GetNumberOfCurrentPlayersForGameAsync(uint appId);
 
-        Task<PlayerAchievementResultModel> GetPlayerAchievementsAsync(uint appId, ulong steamId, string language = "");
+        Task<ISteamWebResponse<PlayerAchievementResultModel>> GetPlayerAchievementsAsync(uint appId, ulong steamId, string language = "");
 
-        Task<SchemaForGameResultModel> GetSchemaForGameAsync(uint appId, string language = "");
+        Task<ISteamWebResponse<SchemaForGameResultModel>> GetSchemaForGameAsync(uint appId, string language = "");
 
-        Task<UserStatsForGameResultModel> GetUserStatsForGameAsync(ulong steamId, uint appId);
+        Task<ISteamWebResponse<UserStatsForGameResultModel>> GetUserStatsForGameAsync(ulong steamId, uint appId);
     }
 }

--- a/SteamWebAPI2/Interfaces/ISteamWebAPIUtil.cs
+++ b/SteamWebAPI2/Interfaces/ISteamWebAPIUtil.cs
@@ -1,4 +1,5 @@
 ﻿using Steam.Models;
+using SteamWebAPI2.Utilities;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -6,8 +7,8 @@ namespace SteamWebAPI2.Interfaces
 {
     public interface ISteamWebAPIUtil
     {
-        Task<SteamServerInfoModel> GetServerInfoAsync();
+        Task<ISteamWebResponse<SteamServerInfoModel>> GetServerInfoAsync();
 
-        Task<IReadOnlyCollection<SteamInterfaceModel>> GetSupportedAPIListAsync();
+        Task<ISteamWebResponse<IReadOnlyCollection<SteamInterfaceModel>>> GetSupportedAPIListAsync();
     }
 }

--- a/SteamWebAPI2/Interfaces/ITFItems.cs
+++ b/SteamWebAPI2/Interfaces/ITFItems.cs
@@ -1,4 +1,5 @@
 ﻿using Steam.Models.TF2;
+using SteamWebAPI2.Utilities;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -6,6 +7,6 @@ namespace SteamWebAPI2.Interfaces
 {
     public interface ITFItems
     {
-        Task<IReadOnlyCollection<GoldenWrenchModel>> GetGoldenWrenchesAsync();
+        Task<ISteamWebResponse<IReadOnlyCollection<GoldenWrenchModel>>> GetGoldenWrenchesAsync();
     }
 }

--- a/SteamWebAPI2/Interfaces/PlayerService.cs
+++ b/SteamWebAPI2/Interfaces/PlayerService.cs
@@ -94,7 +94,9 @@ namespace SteamWebAPI2.Interfaces
                 return null;
             }
 
-            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<BadgesResultContainer>, ISteamWebResponse<BadgesResultModel>>(steamWebResponse);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<BadgesResultContainer>, 
+                ISteamWebResponse<BadgesResultModel>>(steamWebResponse);
 
             return steamWebResponseModel;
         }
@@ -115,7 +117,9 @@ namespace SteamWebAPI2.Interfaces
                 return null;
             }
 
-            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<SteamLevelResultContainer>, ISteamWebResponse<uint?>>(steamWebResponse);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<SteamLevelResultContainer>, 
+                ISteamWebResponse<uint?>>(steamWebResponse);
 
             return steamWebResponseModel;
         }
@@ -169,7 +173,9 @@ namespace SteamWebAPI2.Interfaces
                 }
             }
 
-            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<OwnedGamesResultContainer>, ISteamWebResponse<OwnedGamesResultModel>>(steamWebResponse);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<OwnedGamesResultContainer>, 
+                ISteamWebResponse<OwnedGamesResultModel>>(steamWebResponse);
 
             return steamWebResponseModel;
         }

--- a/SteamWebAPI2/Interfaces/PlayerService.cs
+++ b/SteamWebAPI2/Interfaces/PlayerService.cs
@@ -39,12 +39,14 @@ namespace SteamWebAPI2.Interfaces
 
             var steamWebResponse = await steamWebInterface.GetAsync<PlayingSharedGameResultContainer>("IsPlayingSharedGame", 1, parameters);
 
-            if (steamWebResponse == null || steamWebResponse.Data == null || steamWebResponse.Data.Result == null)
+            if (steamWebResponse == null)
             {
                 return null;
             }
 
-            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<PlayingSharedGameResultContainer>, ISteamWebResponse<ulong?>>(steamWebResponse);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<PlayingSharedGameResultContainer>, 
+                ISteamWebResponse<ulong?>>(steamWebResponse);
 
             return steamWebResponseModel;
         }
@@ -64,7 +66,7 @@ namespace SteamWebAPI2.Interfaces
 
             var steamWebResponse = await steamWebInterface.GetAsync<CommunityBadgeProgressResultContainer>("GetCommunityBadgeProgress", 1, parameters);
 
-            if (steamWebResponse == null || steamWebResponse.Data == null || steamWebResponse.Data.Result == null)
+            if (steamWebResponse == null)
             {
                 return null;
             }
@@ -89,13 +91,13 @@ namespace SteamWebAPI2.Interfaces
 
             var steamWebResponse = await steamWebInterface.GetAsync<BadgesResultContainer>("GetBadges", 1, parameters);
 
-            if (steamWebResponse == null || steamWebResponse.Data == null || steamWebResponse.Data.Result == null)
+            if (steamWebResponse == null)
             {
                 return null;
             }
 
             var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
-                ISteamWebResponse<BadgesResultContainer>, 
+                ISteamWebResponse<BadgesResultContainer>,
                 ISteamWebResponse<BadgesResultModel>>(steamWebResponse);
 
             return steamWebResponseModel;
@@ -112,13 +114,13 @@ namespace SteamWebAPI2.Interfaces
             parameters.AddIfHasValue(steamId, "steamid");
             var steamWebResponse = await steamWebInterface.GetAsync<SteamLevelResultContainer>("GetSteamLevel", 1, parameters);
 
-            if (steamWebResponse == null || steamWebResponse.Data == null || steamWebResponse.Data.Result == null)
+            if (steamWebResponse == null)
             {
                 return null;
             }
 
             var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
-                ISteamWebResponse<SteamLevelResultContainer>, 
+                ISteamWebResponse<SteamLevelResultContainer>,
                 ISteamWebResponse<uint?>>(steamWebResponse);
 
             return steamWebResponseModel;
@@ -156,13 +158,13 @@ namespace SteamWebAPI2.Interfaces
 
             var steamWebResponse = await steamWebInterface.GetAsync<OwnedGamesResultContainer>("GetOwnedGames", 1, parameters);
 
-            if (steamWebResponse == null || steamWebResponse.Data == null || steamWebResponse.Data.Result == null)
+            if (steamWebResponse == null)
             {
                 return null;
             }
 
             // for some reason, some games have trailing spaces in the result so let's get rid of them
-            if (steamWebResponse.Data.Result.OwnedGames != null)
+            if (steamWebResponse.Data != null && steamWebResponse.Data.Result != null && steamWebResponse.Data.Result.OwnedGames != null)
             {
                 foreach (var ownedGame in steamWebResponse.Data.Result.OwnedGames)
                 {
@@ -174,7 +176,7 @@ namespace SteamWebAPI2.Interfaces
             }
 
             var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
-                ISteamWebResponse<OwnedGamesResultContainer>, 
+                ISteamWebResponse<OwnedGamesResultContainer>,
                 ISteamWebResponse<OwnedGamesResultModel>>(steamWebResponse);
 
             return steamWebResponseModel;
@@ -192,13 +194,13 @@ namespace SteamWebAPI2.Interfaces
 
             var steamWebResponse = await steamWebInterface.GetAsync<RecentlyPlayedGameResultContainer>("GetRecentlyPlayedGames", 1, parameters);
 
-            if (steamWebResponse == null || steamWebResponse.Data == null || steamWebResponse.Data.Result == null)
+            if (steamWebResponse == null)
             {
                 return null;
             }
 
             var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
-                ISteamWebResponse<RecentlyPlayedGameResultContainer>, 
+                ISteamWebResponse<RecentlyPlayedGameResultContainer>,
                 ISteamWebResponse<RecentlyPlayedGamesResultModel>>(steamWebResponse);
 
             return steamWebResponseModel;

--- a/SteamWebAPI2/Interfaces/PlayerService.cs
+++ b/SteamWebAPI2/Interfaces/PlayerService.cs
@@ -30,21 +30,23 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="steamId"></param>
         /// <param name="appId"></param>
         /// <returns></returns>
-        public async Task<ulong?> IsPlayingSharedGameAsync(ulong steamId, uint appId)
+        public async Task<ISteamWebResponse<ulong?>> IsPlayingSharedGameAsync(ulong steamId, uint appId)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
 
             parameters.AddIfHasValue(steamId, "steamid");
             parameters.AddIfHasValue(appId, "appid_playing");
 
-            var playingSharedGameResult = await steamWebInterface.GetAsync<PlayingSharedGameResultContainer>("IsPlayingSharedGame", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<PlayingSharedGameResultContainer>("IsPlayingSharedGame", 1, parameters);
 
-            if (playingSharedGameResult == null || playingSharedGameResult.Result == null)
+            if (steamWebResponse == null || steamWebResponse.Data == null || steamWebResponse.Data.Result == null)
             {
                 return null;
             }
 
-            return playingSharedGameResult.Result.LenderSteamId;
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<PlayingSharedGameResultContainer>, ISteamWebResponse<ulong?>>(steamWebResponse);
+
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -53,21 +55,25 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="steamId"></param>
         /// <param name="badgeId"></param>
         /// <returns></returns>
-        public async Task<IReadOnlyCollection<BadgeQuestModel>> GetCommunityBadgeProgressAsync(ulong steamId, uint? badgeId = null)
+        public async Task<ISteamWebResponse<IReadOnlyCollection<BadgeQuestModel>>> GetCommunityBadgeProgressAsync(ulong steamId, uint? badgeId = null)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
+
             parameters.AddIfHasValue(steamId, "steamid");
             parameters.AddIfHasValue(badgeId, "badgeid");
-            var badgeProgressResult = await steamWebInterface.GetAsync<CommunityBadgeProgressResultContainer>("GetCommunityBadgeProgress", 1, parameters);
 
-            if (badgeProgressResult == null || badgeProgressResult.Result == null)
+            var steamWebResponse = await steamWebInterface.GetAsync<CommunityBadgeProgressResultContainer>("GetCommunityBadgeProgress", 1, parameters);
+
+            if (steamWebResponse == null || steamWebResponse.Data == null || steamWebResponse.Data.Result == null)
             {
                 return null;
             }
 
-            var badgeProgressModels = AutoMapperConfiguration.Mapper.Map<IList<BadgeQuest>, IList<BadgeQuestModel>>(badgeProgressResult.Result.Quests);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<CommunityBadgeProgressResultContainer>,
+                ISteamWebResponse<IReadOnlyCollection<BadgeQuestModel>>>(steamWebResponse);
 
-            return new ReadOnlyCollection<BadgeQuestModel>(badgeProgressModels);
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -75,20 +81,22 @@ namespace SteamWebAPI2.Interfaces
         /// </summary>
         /// <param name="steamId"></param>
         /// <returns></returns>
-        public async Task<BadgesResultModel> GetBadgesAsync(ulong steamId)
+        public async Task<ISteamWebResponse<BadgesResultModel>> GetBadgesAsync(ulong steamId)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
-            parameters.AddIfHasValue(steamId, "steamid");
-            var badgesResult = await steamWebInterface.GetAsync<BadgesResultContainer>("GetBadges", 1, parameters);
 
-            if (badgesResult == null || badgesResult.Result == null)
+            parameters.AddIfHasValue(steamId, "steamid");
+
+            var steamWebResponse = await steamWebInterface.GetAsync<BadgesResultContainer>("GetBadges", 1, parameters);
+
+            if (steamWebResponse == null || steamWebResponse.Data == null || steamWebResponse.Data.Result == null)
             {
                 return null;
             }
 
-            var badgesResultModel = AutoMapperConfiguration.Mapper.Map<BadgesResult, BadgesResultModel>(badgesResult.Result);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<BadgesResultContainer>, ISteamWebResponse<BadgesResultModel>>(steamWebResponse);
 
-            return badgesResultModel;
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -96,18 +104,20 @@ namespace SteamWebAPI2.Interfaces
         /// </summary>
         /// <param name="steamId"></param>
         /// <returns></returns>
-        public async Task<uint?> GetSteamLevelAsync(ulong steamId)
+        public async Task<ISteamWebResponse<uint?>> GetSteamLevelAsync(ulong steamId)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
             parameters.AddIfHasValue(steamId, "steamid");
-            var steamLevelResult = await steamWebInterface.GetAsync<SteamLevelResultContainer>("GetSteamLevel", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<SteamLevelResultContainer>("GetSteamLevel", 1, parameters);
 
-            if (steamLevelResult == null || steamLevelResult.Result == null)
+            if (steamWebResponse == null || steamWebResponse.Data == null || steamWebResponse.Data.Result == null)
             {
                 return null;
             }
 
-            return steamLevelResult.Result.PlayerLevel;
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<SteamLevelResultContainer>, ISteamWebResponse<uint?>>(steamWebResponse);
+
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -118,11 +128,13 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="includeFreeGames"></param>
         /// <param name="appIdsToFilter"></param>
         /// <returns></returns>
-        public async Task<OwnedGamesResultModel> GetOwnedGamesAsync(ulong steamId, bool? includeAppInfo = null, bool? includeFreeGames = null, IReadOnlyCollection<uint> appIdsToFilter = null)
+        public async Task<ISteamWebResponse<OwnedGamesResultModel>> GetOwnedGamesAsync(ulong steamId, bool? includeAppInfo = null, bool? includeFreeGames = null, IReadOnlyCollection<uint> appIdsToFilter = null)
         {
+            // translate boolean to 0/1 since that's what the Steam Web API expects
             int? includeAppInfoBit = 0;
             if (includeAppInfo.HasValue) { includeAppInfoBit = includeAppInfo.Value ? 1 : 0; }
 
+            // translate boolean to 0/1 since that's what Steam Web API expects
             int? includeFreeGamesBit = 0;
             if (includeFreeGames.HasValue) { includeFreeGamesBit = includeFreeGames.Value ? 1 : 0; }
 
@@ -131,23 +143,24 @@ namespace SteamWebAPI2.Interfaces
             parameters.AddIfHasValue(steamId, "steamid");
             parameters.AddIfHasValue(includeAppInfoBit, "include_appinfo");
 
+            // join the app ids by commas since that's what the Steam Web API expects
             if (appIdsToFilter != null)
             {
                 string appIdsDelimited = String.Join(",", appIdsToFilter);
                 parameters.AddIfHasValue(appIdsDelimited, "appids_filter");
             }
 
-            var ownedGamesResult = await steamWebInterface.GetAsync<OwnedGamesResultContainer>("GetOwnedGames", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<OwnedGamesResultContainer>("GetOwnedGames", 1, parameters);
 
-            if (ownedGamesResult == null || ownedGamesResult.Result == null)
+            if (steamWebResponse == null || steamWebResponse.Data == null || steamWebResponse.Data.Result == null)
             {
                 return null;
             }
 
-            // for some reason, some games have trailing spaces in the result
-            if (ownedGamesResult.Result.OwnedGames != null)
+            // for some reason, some games have trailing spaces in the result so let's get rid of them
+            if (steamWebResponse.Data.Result.OwnedGames != null)
             {
-                foreach (var ownedGame in ownedGamesResult.Result.OwnedGames)
+                foreach (var ownedGame in steamWebResponse.Data.Result.OwnedGames)
                 {
                     if (!String.IsNullOrWhiteSpace(ownedGame.Name))
                     {
@@ -156,9 +169,9 @@ namespace SteamWebAPI2.Interfaces
                 }
             }
 
-            var ownedGamesResultModel = AutoMapperConfiguration.Mapper.Map<OwnedGamesResult, OwnedGamesResultModel>(ownedGamesResult.Result);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<OwnedGamesResultContainer>, ISteamWebResponse<OwnedGamesResultModel>>(steamWebResponse);
 
-            return ownedGamesResultModel;
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -166,20 +179,23 @@ namespace SteamWebAPI2.Interfaces
         /// </summary>
         /// <param name="steamId"></param>
         /// <returns></returns>
-        public async Task<RecentlyPlayedGamesResultModel> GetRecentlyPlayedGamesAsync(ulong steamId)
+        public async Task<ISteamWebResponse<RecentlyPlayedGamesResultModel>> GetRecentlyPlayedGamesAsync(ulong steamId)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
             parameters.AddIfHasValue(steamId, "steamid");
-            var recentlyPlayedGamesResult = await steamWebInterface.GetAsync<RecentlyPlayedGameResultContainer>("GetRecentlyPlayedGames", 1, parameters);
 
-            if (recentlyPlayedGamesResult == null || recentlyPlayedGamesResult.Result == null)
+            var steamWebResponse = await steamWebInterface.GetAsync<RecentlyPlayedGameResultContainer>("GetRecentlyPlayedGames", 1, parameters);
+
+            if (steamWebResponse == null || steamWebResponse.Data == null || steamWebResponse.Data.Result == null)
             {
                 return null;
             }
 
-            var recentlyPlayedGamesResultModel = AutoMapperConfiguration.Mapper.Map<RecentlyPlayedGameResult, RecentlyPlayedGamesResultModel>(recentlyPlayedGamesResult.Result);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<RecentlyPlayedGameResultContainer>, 
+                ISteamWebResponse<RecentlyPlayedGamesResultModel>>(steamWebResponse);
 
-            return recentlyPlayedGamesResultModel;
+            return steamWebResponseModel;
         }
     }
 }

--- a/SteamWebAPI2/Interfaces/SteamApps.cs
+++ b/SteamWebAPI2/Interfaces/SteamApps.cs
@@ -26,11 +26,15 @@ namespace SteamWebAPI2.Interfaces
         /// Returns a list of all Steam Apps.
         /// </summary>
         /// <returns></returns>
-        public async Task<IReadOnlyCollection<SteamAppModel>> GetAppListAsync()
+        public async Task<ISteamWebResponse<IReadOnlyCollection<SteamAppModel>>> GetAppListAsync()
         {
-            var steamAppList = await steamWebInterface.GetAsync<SteamAppListResultContainer>("GetAppList", 2);
-            var steamAppModels = AutoMapperConfiguration.Mapper.Map<IList<SteamApp>, IList<SteamAppModel>>(steamAppList.Result.Apps);
-            return new ReadOnlyCollection<SteamAppModel>(steamAppModels);
+            var steamWebResponse = await steamWebInterface.GetAsync<SteamAppListResultContainer>("GetAppList", 2);
+
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<SteamAppListResultContainer>,
+                ISteamWebResponse<IReadOnlyCollection<SteamAppModel>>>(steamWebResponse);
+
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -39,16 +43,20 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="appId"></param>
         /// <param name="version"></param>
         /// <returns></returns>
-        public async Task<SteamAppUpToDateCheckModel> UpToDateCheckAsync(uint appId, uint version)
+        public async Task<ISteamWebResponse<SteamAppUpToDateCheckModel>> UpToDateCheckAsync(uint appId, uint version)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
 
             parameters.AddIfHasValue(appId, "appid");
             parameters.AddIfHasValue(version, "version");
 
-            var upToDateCheckResult = await steamWebInterface.GetAsync<SteamAppUpToDateCheckResultContainer>("UpToDateCheck", 1, parameters);
-            var upToDateCheckModel = AutoMapperConfiguration.Mapper.Map<SteamAppUpToDateCheckResult, SteamAppUpToDateCheckModel>(upToDateCheckResult.Result);
-            return upToDateCheckModel;
+            var steamWebResponse = await steamWebInterface.GetAsync<SteamAppUpToDateCheckResultContainer>("UpToDateCheck", 1, parameters);
+
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<SteamAppUpToDateCheckResultContainer>, 
+                ISteamWebResponse<SteamAppUpToDateCheckModel>>(steamWebResponse);
+
+            return steamWebResponseModel;
         }
     }
 }

--- a/SteamWebAPI2/Interfaces/SteamEconomy.cs
+++ b/SteamWebAPI2/Interfaces/SteamEconomy.cs
@@ -29,7 +29,7 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="classIds"></param>
         /// <param name="language"></param>
         /// <returns></returns>
-        public async Task<AssetClassInfoResultModel> GetAssetClassInfoAsync(uint appId, IReadOnlyList<ulong> classIds, string language = "en_us")
+        public async Task<ISteamWebResponse<AssetClassInfoResultModel>> GetAssetClassInfoAsync(uint appId, IReadOnlyList<ulong> classIds, string language = "en_us")
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
 
@@ -42,11 +42,11 @@ namespace SteamWebAPI2.Interfaces
                 parameters.AddIfHasValue(classIds[i], String.Format("classid{0}", i));
             }
 
-            var assetClassInfoResult = await steamWebInterface.GetAsync<AssetClassInfoResultContainer>("GetAssetClassInfo", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<AssetClassInfoResultContainer>("GetAssetClassInfo", 1, parameters);
 
-            var assetClassInfoResultModel = AutoMapperConfiguration.Mapper.Map<AssetClassInfoResult, AssetClassInfoResultModel>(assetClassInfoResult.Result);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<AssetClassInfoResultContainer>, ISteamWebResponse<AssetClassInfoResultModel>>(steamWebResponse);
 
-            return assetClassInfoResultModel;
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="currency"></param>
         /// <param name="language"></param>
         /// <returns></returns>
-        public async Task<AssetPriceResultModel> GetAssetPricesAsync(uint appId, string currency = "", string language = "en_us")
+        public async Task<ISteamWebResponse<AssetPriceResultModel>> GetAssetPricesAsync(uint appId, string currency = "", string language = "en_us")
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
 
@@ -64,11 +64,11 @@ namespace SteamWebAPI2.Interfaces
             parameters.AddIfHasValue(currency, "currency");
             parameters.AddIfHasValue(language, "language");
 
-            var assetPriceResult = await steamWebInterface.GetAsync<AssetPriceResultContainer>("GetAssetPrices", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<AssetPriceResultContainer>("GetAssetPrices", 1, parameters);
 
-            var assetPriceResultModel = AutoMapperConfiguration.Mapper.Map<AssetPriceResult, AssetPriceResultModel>(assetPriceResult.Result);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<AssetPriceResultContainer>, ISteamWebResponse<AssetPriceResultModel>>(steamWebResponse);
 
-            return assetPriceResultModel;
+            return steamWebResponseModel;
         }
     }
 }

--- a/SteamWebAPI2/Interfaces/SteamEconomy.cs
+++ b/SteamWebAPI2/Interfaces/SteamEconomy.cs
@@ -44,7 +44,9 @@ namespace SteamWebAPI2.Interfaces
 
             var steamWebResponse = await steamWebInterface.GetAsync<AssetClassInfoResultContainer>("GetAssetClassInfo", 1, parameters);
 
-            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<AssetClassInfoResultContainer>, ISteamWebResponse<AssetClassInfoResultModel>>(steamWebResponse);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<AssetClassInfoResultContainer>,
+                ISteamWebResponse<AssetClassInfoResultModel>>(steamWebResponse);
 
             return steamWebResponseModel;
         }
@@ -66,7 +68,9 @@ namespace SteamWebAPI2.Interfaces
 
             var steamWebResponse = await steamWebInterface.GetAsync<AssetPriceResultContainer>("GetAssetPrices", 1, parameters);
 
-            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<AssetPriceResultContainer>, ISteamWebResponse<AssetPriceResultModel>>(steamWebResponse);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<AssetPriceResultContainer>, 
+                ISteamWebResponse<AssetPriceResultModel>>(steamWebResponse);
 
             return steamWebResponseModel;
         }

--- a/SteamWebAPI2/Interfaces/SteamNews.cs
+++ b/SteamWebAPI2/Interfaces/SteamNews.cs
@@ -48,7 +48,9 @@ namespace SteamWebAPI2.Interfaces
 
             var steamWebResponse = await steamWebInterface.GetAsync<SteamNewsResultContainer>("GetNewsForApp", 2, parameters);
 
-            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<SteamNewsResultContainer>, ISteamWebResponse<SteamNewsResultModel>>(steamWebResponse);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<SteamNewsResultContainer>, 
+                ISteamWebResponse<SteamNewsResultModel>>(steamWebResponse);
 
             return steamWebResponseModel;
         }

--- a/SteamWebAPI2/Interfaces/SteamNews.cs
+++ b/SteamWebAPI2/Interfaces/SteamNews.cs
@@ -30,7 +30,7 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="endDate"></param>
         /// <param name="count"></param>
         /// <returns></returns>
-        public async Task<SteamNewsResultModel> GetNewsForAppAsync(uint appId, uint? maxLength = null, DateTime? endDate = null, uint? count = null)
+        public async Task<ISteamWebResponse<SteamNewsResultModel>> GetNewsForAppAsync(uint appId, uint? maxLength = null, DateTime? endDate = null, uint? count = null)
         {
             long? endDateUnixTimeStamp = null;
 
@@ -46,11 +46,11 @@ namespace SteamWebAPI2.Interfaces
             parameters.AddIfHasValue(endDateUnixTimeStamp, "enddate");
             parameters.AddIfHasValue(count, "count");
 
-            var appNews = await steamWebInterface.GetAsync<SteamNewsResultContainer>("GetNewsForApp", 2, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<SteamNewsResultContainer>("GetNewsForApp", 2, parameters);
 
-            var appNewsModel = AutoMapperConfiguration.Mapper.Map<SteamNewsResult, SteamNewsResultModel>(appNews.Result);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<SteamNewsResultContainer>, ISteamWebResponse<SteamNewsResultModel>>(steamWebResponse);
 
-            return appNewsModel;
+            return steamWebResponseModel;
         }
     }
 }

--- a/SteamWebAPI2/Interfaces/SteamRemoteStorage.cs
+++ b/SteamWebAPI2/Interfaces/SteamRemoteStorage.cs
@@ -44,7 +44,9 @@ namespace SteamWebAPI2.Interfaces
             {
                 var steamWebResponse = await steamWebInterface.GetAsync<UGCFileDetailsResultContainer>("GetUGCFileDetails", 1, parameters);
 
-                var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<UGCFileDetailsResultContainer>, ISteamWebResponse<UGCFileDetailsModel>>(steamWebResponse);
+                var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                    ISteamWebResponse<UGCFileDetailsResultContainer>, 
+                    ISteamWebResponse<UGCFileDetailsModel>>(steamWebResponse);
 
                 return steamWebResponseModel;
             }

--- a/SteamWebAPI2/Interfaces/SteamRemoteStorage.cs
+++ b/SteamWebAPI2/Interfaces/SteamRemoteStorage.cs
@@ -30,14 +30,9 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="appId"></param>
         /// <param name="steamId"></param>
         /// <returns></returns>
-        public async Task<UGCFileDetailsModel> GetUGCFileDetailsAsync(ulong ugcId, uint appId, ulong? steamId = null)
+        public async Task<ISteamWebResponse<UGCFileDetailsModel>> GetUGCFileDetailsAsync(ulong ugcId, uint appId, ulong? steamId = null)
         {
             Debug.Assert(appId > 0);
-
-            if (ugcId <= 0)
-            {
-                return null;
-            }
 
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
 
@@ -47,11 +42,11 @@ namespace SteamWebAPI2.Interfaces
 
             try
             {
-                var ugcFileDetails = await steamWebInterface.GetAsync<UGCFileDetailsResultContainer>("GetUGCFileDetails", 1, parameters);
+                var steamWebResponse = await steamWebInterface.GetAsync<UGCFileDetailsResultContainer>("GetUGCFileDetails", 1, parameters);
 
-                var ugcFileDetailsModel = AutoMapperConfiguration.Mapper.Map<UGCFileDetails, UGCFileDetailsModel>(ugcFileDetails.Result);
+                var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<ISteamWebResponse<UGCFileDetailsResultContainer>, ISteamWebResponse<UGCFileDetailsModel>>(steamWebResponse);
 
-                return ugcFileDetailsModel;
+                return steamWebResponseModel;
             }
             catch (HttpRequestException)
             {

--- a/SteamWebAPI2/Interfaces/SteamUserAuth.cs
+++ b/SteamWebAPI2/Interfaces/SteamUserAuth.cs
@@ -25,7 +25,7 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="appId">App ID of the game to authenticate against</param>
         /// <param name="ticket">Ticket from GetAuthSessionTicket</param>
         /// <returns>Results of authentication request</returns>
-        public async Task<dynamic> AuthenticateUserTicket(uint appId, string ticket)
+        public async Task<ISteamWebResponse<dynamic>> AuthenticateUserTicket(uint appId, string ticket)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
             parameters.AddIfHasValue(appId, "appid");

--- a/SteamWebAPI2/Interfaces/SteamUserStats.cs
+++ b/SteamWebAPI2/Interfaces/SteamUserStats.cs
@@ -32,16 +32,18 @@ namespace SteamWebAPI2.Interfaces
         /// </summary>
         /// <param name="appId"></param>
         /// <returns></returns>
-        public async Task<IReadOnlyCollection<GlobalAchievementPercentageModel>> GetGlobalAchievementPercentagesForAppAsync(uint appId)
+        public async Task<ISteamWebResponse<IReadOnlyCollection<GlobalAchievementPercentageModel>>> GetGlobalAchievementPercentagesForAppAsync(uint appId)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
             parameters.AddIfHasValue(appId, "gameid");
 
-            var achievementPercentagesResult = await steamWebInterface.GetAsync<GlobalAchievementPercentagesResultContainer>("GetGlobalAchievementPercentagesForApp", 2, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<GlobalAchievementPercentagesResultContainer>("GetGlobalAchievementPercentagesForApp", 2, parameters);
 
-            var achievementPercentagesResultModel = AutoMapperConfiguration.Mapper.Map<IList<GlobalAchievementPercentage>, IList<GlobalAchievementPercentageModel>>(achievementPercentagesResult.Result.AchievementPercentages);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<GlobalAchievementPercentagesResultContainer>,
+                ISteamWebResponse<IReadOnlyCollection<GlobalAchievementPercentageModel>>>(steamWebResponse);
 
-            return new ReadOnlyCollection<GlobalAchievementPercentageModel>(achievementPercentagesResultModel);
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -52,7 +54,7 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="startDate"></param>
         /// <param name="endDate"></param>
         /// <returns></returns>
-        public async Task<IReadOnlyCollection<GlobalStatModel>> GetGlobalStatsForGameAsync(uint appId, IReadOnlyList<string> statNames, DateTime? startDate = null, DateTime? endDate = null)
+        public async Task<ISteamWebResponse<IReadOnlyCollection<GlobalStatModel>>> GetGlobalStatsForGameAsync(uint appId, IReadOnlyList<string> statNames, DateTime? startDate = null, DateTime? endDate = null)
         {
             long? startDateUnixTimeStamp = null;
             long? endDateUnixTimeStamp = null;
@@ -78,11 +80,13 @@ namespace SteamWebAPI2.Interfaces
                 parameters.AddIfHasValue(statNames[i], String.Format("name[{0}]", i));
             }
 
-            var globalStatsResult = await steamWebInterface.GetAsync<GlobalStatsForGameResultContainer>("GetGlobalStatsForGame", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<GlobalStatsForGameResultContainer>("GetGlobalStatsForGame", 1, parameters);
 
-            var globalStatsModel = AutoMapperConfiguration.Mapper.Map<IList<GlobalStat>, IList<GlobalStatModel>>(globalStatsResult.Result.GlobalStats);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<GlobalStatsForGameResultContainer>,
+                ISteamWebResponse<IReadOnlyCollection<GlobalStatModel>>>(steamWebResponse);
 
-            return new ReadOnlyCollection<GlobalStatModel>(globalStatsModel);
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -90,14 +94,18 @@ namespace SteamWebAPI2.Interfaces
         /// </summary>
         /// <param name="appId"></param>
         /// <returns></returns>
-        public async Task<uint> GetNumberOfCurrentPlayersForGameAsync(uint appId)
+        public async Task<ISteamWebResponse<uint>> GetNumberOfCurrentPlayersForGameAsync(uint appId)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
             parameters.AddIfHasValue(appId, "appid");
 
-            var globalStatsResult = await steamWebInterface.GetAsync<CurrentPlayersResultContainer>("GetNumberOfCurrentPlayers", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<CurrentPlayersResultContainer>("GetNumberOfCurrentPlayers", 1, parameters);
 
-            return globalStatsResult.Result.PlayerCount;
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<CurrentPlayersResultContainer>,
+                ISteamWebResponse<uint>>(steamWebResponse);
+
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -107,18 +115,20 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="steamId"></param>
         /// <param name="language"></param>
         /// <returns></returns>
-        public async Task<PlayerAchievementResultModel> GetPlayerAchievementsAsync(uint appId, ulong steamId, string language = "en_us")
+        public async Task<ISteamWebResponse<PlayerAchievementResultModel>> GetPlayerAchievementsAsync(uint appId, ulong steamId, string language = "en_us")
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
             parameters.AddIfHasValue(appId, "appid");
             parameters.AddIfHasValue(steamId, "steamid");
             parameters.AddIfHasValue(language, "l");
 
-            var playerStatsResult = await steamWebInterface.GetAsync<PlayerAchievementResultContainer>("GetPlayerAchievements", 1, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<PlayerAchievementResultContainer>("GetPlayerAchievements", 1, parameters);
 
-            var playerStatsResultModel = AutoMapperConfiguration.Mapper.Map<PlayerAchievementResult, PlayerAchievementResultModel>(playerStatsResult.Result);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<PlayerAchievementResultContainer>,
+                ISteamWebResponse<PlayerAchievementResultModel>>(steamWebResponse);
 
-            return playerStatsResultModel;
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -127,17 +137,19 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="appId"></param>
         /// <param name="language"></param>
         /// <returns></returns>
-        public async Task<SchemaForGameResultModel> GetSchemaForGameAsync(uint appId, string language = "")
+        public async Task<ISteamWebResponse<SchemaForGameResultModel>> GetSchemaForGameAsync(uint appId, string language = "")
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
             parameters.AddIfHasValue(appId, "appid");
             parameters.AddIfHasValue(language, "l");
 
-            var schemaForGameResult = await steamWebInterface.GetAsync<SchemaForGameResultContainer>("GetSchemaForGame", 2, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<SchemaForGameResultContainer>("GetSchemaForGame", 2, parameters);
 
-            var schemaForGameResultModel = AutoMapperConfiguration.Mapper.Map<SchemaForGameResult, SchemaForGameResultModel>(schemaForGameResult.Result);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<SchemaForGameResultContainer>,
+                ISteamWebResponse<SchemaForGameResultModel>>(steamWebResponse);
 
-            return schemaForGameResultModel;
+            return steamWebResponseModel;
         }
 
         /// <summary>
@@ -146,17 +158,19 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="steamId"></param>
         /// <param name="appId"></param>
         /// <returns></returns>
-        public async Task<UserStatsForGameResultModel> GetUserStatsForGameAsync(ulong steamId, uint appId)
+        public async Task<ISteamWebResponse<UserStatsForGameResultModel>> GetUserStatsForGameAsync(ulong steamId, uint appId)
         {
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
             parameters.AddIfHasValue(steamId, "steamid");
             parameters.AddIfHasValue(appId, "appid");
 
-            var userStatsForGameResult = await steamWebInterface.GetAsync<UserStatsForGameResultContainer>("GetUserStatsForGame", 2, parameters);
+            var steamWebResponse = await steamWebInterface.GetAsync<UserStatsForGameResultContainer>("GetUserStatsForGame", 2, parameters);
 
-            var userStatsForGameResultModel = AutoMapperConfiguration.Mapper.Map<UserStatsForGameResult, UserStatsForGameResultModel>(userStatsForGameResult.Result);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<UserStatsForGameResultContainer>, 
+                ISteamWebResponse<UserStatsForGameResultModel>>(steamWebResponse);
 
-            return userStatsForGameResultModel;
+            return steamWebResponseModel;
         }
     }
 }

--- a/SteamWebAPI2/Interfaces/SteamWebAPIUtil.cs
+++ b/SteamWebAPI2/Interfaces/SteamWebAPIUtil.cs
@@ -26,11 +26,13 @@ namespace SteamWebAPI2.Interfaces
         /// Returns the Steam Servers' known dates and times.
         /// </summary>
         /// <returns></returns>
-        public async Task<SteamServerInfoModel> GetServerInfoAsync()
+        public async Task<ISteamWebResponse<SteamServerInfoModel>> GetServerInfoAsync()
         {
             var steamServerInfo = await steamWebInterface.GetAsync<SteamServerInfo>("GetServerInfo", 1);
 
-            var steamServerInfoModel = AutoMapperConfiguration.Mapper.Map<SteamServerInfo, SteamServerInfoModel>(steamServerInfo);
+            var steamServerInfoModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<SteamServerInfo>, 
+                ISteamWebResponse<SteamServerInfoModel>>(steamServerInfo);
 
             return steamServerInfoModel;
         }
@@ -39,13 +41,15 @@ namespace SteamWebAPI2.Interfaces
         /// Returns a collection of data related to all available supported Steam Web API endpoints.
         /// </summary>
         /// <returns></returns>
-        public async Task<IReadOnlyCollection<SteamInterfaceModel>> GetSupportedAPIListAsync()
+        public async Task<ISteamWebResponse<IReadOnlyCollection<SteamInterfaceModel>>> GetSupportedAPIListAsync()
         {
-            var steamApiListContainer = await steamWebInterface.GetAsync<SteamApiListContainer>("GetSupportedAPIList", 1);
+            var steamWebResponse = await steamWebInterface.GetAsync<SteamApiListContainer>("GetSupportedAPIList", 1);
 
-            var steamApiListModel = AutoMapperConfiguration.Mapper.Map<IList<SteamInterface>, IList<SteamInterfaceModel>>(steamApiListContainer.Result.Interfaces);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<SteamApiListContainer>, 
+                ISteamWebResponse<IReadOnlyCollection<SteamInterfaceModel>>>(steamWebResponse);
 
-            return new ReadOnlyCollection<SteamInterfaceModel>(steamApiListModel);
+            return steamWebResponseModel;
         }
     }
 }

--- a/SteamWebAPI2/Interfaces/TFItems.cs
+++ b/SteamWebAPI2/Interfaces/TFItems.cs
@@ -26,13 +26,15 @@ namespace SteamWebAPI2.Interfaces
         /// Returns a collection of golden wrench and their collection details.
         /// </summary>
         /// <returns></returns>
-        public async Task<IReadOnlyCollection<GoldenWrenchModel>> GetGoldenWrenchesAsync()
+        public async Task<ISteamWebResponse<IReadOnlyCollection<GoldenWrenchModel>>> GetGoldenWrenchesAsync()
         {
-            var goldenWrenchesResult = await steamWebInterface.GetAsync<GoldenWrenchResultContainer>("GetGoldenWrenches", 2);
+            var steamWebResponse = await steamWebInterface.GetAsync<GoldenWrenchResultContainer>("GetGoldenWrenches", 2);
 
-            var goldenWrenchModels = AutoMapperConfiguration.Mapper.Map<IList<GoldenWrench>, IList<GoldenWrenchModel>>(goldenWrenchesResult.Result.GoldenWrenches);
+            var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                ISteamWebResponse<GoldenWrenchResultContainer>, 
+                ISteamWebResponse<IReadOnlyCollection<GoldenWrenchModel>>>(steamWebResponse);
 
-            return new ReadOnlyCollection<GoldenWrenchModel>(goldenWrenchModels);
+            return steamWebResponseModel;
         }
     }
 }

--- a/SteamWebAPI2/Models/DOTA2/MatchDetailResultContainer.cs
+++ b/SteamWebAPI2/Models/DOTA2/MatchDetailResultContainer.cs
@@ -99,7 +99,7 @@ namespace SteamWebAPI2.Models.DOTA2
         public uint Duration { get; set; }
 
         [JsonProperty(PropertyName = "start_time")]
-        public uint StartTime { get; set; }
+        public long StartTime { get; set; }
 
         [JsonProperty(PropertyName = "match_id")]
         public ulong MatchId { get; set; }

--- a/SteamWebAPI2/Models/DOTA2/ProPlayerListResultContainer.cs
+++ b/SteamWebAPI2/Models/DOTA2/ProPlayerListResultContainer.cs
@@ -46,10 +46,4 @@ namespace SteamWebAPI2.Models.DOTA2
 
         public IList<ProPlayerLeaderboard> Leaderboards { get; set; }
     }
-
-    internal class ProPlayerListResultContainer
-    {
-        [JsonProperty(PropertyName = "results")]
-        public ProPlayerListResult Result { get; set; }
-    }
 }

--- a/SteamWebAPI2/Models/DOTA2/ProPlayerListResultContainer.cs
+++ b/SteamWebAPI2/Models/DOTA2/ProPlayerListResultContainer.cs
@@ -42,7 +42,7 @@ namespace SteamWebAPI2.Models.DOTA2
     internal class ProPlayerListResult
     {
         [JsonProperty(PropertyName = "player_infos")]
-        public IList<ProPlayerInfo> PlayerInfos { get; set; }
+        public IList<ProPlayerInfo> ProPlayers { get; set; }
 
         public IList<ProPlayerLeaderboard> Leaderboards { get; set; }
     }

--- a/SteamWebAPI2/Models/GameClientResultContainer.cs
+++ b/SteamWebAPI2/Models/GameClientResultContainer.cs
@@ -8,10 +8,10 @@ namespace SteamWebAPI2.Models
         public bool Success { get; set; }
 
         [JsonProperty("deploy_version")]
-        public int DeployVersion { get; set; }
+        public uint DeployVersion { get; set; }
 
         [JsonProperty("active_version")]
-        public int ActiveVersion { get; set; }
+        public uint ActiveVersion { get; set; }
     }
 
     internal class GameClientResultContainer

--- a/SteamWebAPI2/Models/SteamId.cs
+++ b/SteamWebAPI2/Models/SteamId.cs
@@ -411,7 +411,7 @@ namespace SteamWebAPI2.Models
             ulong steamId64 = 0;
 
             var steamId = await steamUser.ResolveVanityUrlAsync(value);
-            steamId64 = steamId;
+            steamId64 = steamId.Data;
 
             return steamId64;
         }

--- a/SteamWebAPI2/Properties/AssemblyInfo.cs
+++ b/SteamWebAPI2/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyVersion("3.1.0.0")]
 [assembly: AssemblyFileVersion("3.0.0.0")]
 
 [assembly: InternalsVisibleTo("SteamWebAPI2.Tests")]

--- a/SteamWebAPI2/SteamWebAPI2.csproj
+++ b/SteamWebAPI2/SteamWebAPI2.csproj
@@ -30,8 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AutoMapper, Version=4.2.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoMapper.4.2.1\lib\net45\AutoMapper.dll</HintPath>
+    <Reference Include="AutoMapper, Version=5.2.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.5.2.0\lib\net45\AutoMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/SteamWebAPI2/SteamWebAPI2.csproj
+++ b/SteamWebAPI2/SteamWebAPI2.csproj
@@ -38,8 +38,8 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Steam.Models, Version=2.0.0.2, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Steam.Models.2.0.0.2\lib\net46\Steam.Models.dll</HintPath>
+    <Reference Include="Steam.Models, Version=2.0.0.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\Projects\TestSteamWebAPI2\packages\Steam.Models.2.0.0.3\lib\net46\Steam.Models.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/SteamWebAPI2/SteamWebAPI2.csproj
+++ b/SteamWebAPI2/SteamWebAPI2.csproj
@@ -178,6 +178,8 @@
     <Compile Include="Utilities\JsonConverters\UnixTimeJsonConverter.cs" />
     <Compile Include="Utilities\SteamWebHttpClient.cs" />
     <Compile Include="Utilities\SteamWebRequestParameterExtensions.cs" />
+    <Compile Include="Utilities\ISteamWebResponse.cs" />
+    <Compile Include="Utilities\SteamWebResponse.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="ErrorMessages.resx">

--- a/SteamWebAPI2/SteamWebAPI2.nuspec
+++ b/SteamWebAPI2/SteamWebAPI2.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright 2017</copyright>
     <tags>steam webapi json community</tags>
     <dependencies>
-      <dependency id="AutoMapper" version="[4.2.1]" />
+      <dependency id="AutoMapper" version="[5.2.0]" />
     </dependencies>
   </metadata>
   <files>

--- a/SteamWebAPI2/Utilities/DateTimeExtensions.cs
+++ b/SteamWebAPI2/Utilities/DateTimeExtensions.cs
@@ -16,7 +16,7 @@ namespace SteamWebAPI2.Utilities
         }
 
         /// <summary>
-        /// Converts a DateTiem to Unix time
+        /// Converts a DateTime to Unix time
         /// </summary>
         /// <param name="dateTime"></param>
         /// <returns></returns>

--- a/SteamWebAPI2/Utilities/ISteamWebHttpClient.cs
+++ b/SteamWebAPI2/Utilities/ISteamWebHttpClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace SteamWebAPI2.Utilities
 {
@@ -9,13 +10,13 @@ namespace SteamWebAPI2.Utilities
         /// </summary>
         /// <param name="command">URL command for GET operation</param>
         /// <returns>String response such as JSON or XML</returns>
-        Task<string> GetStringAsync(string uri);
+        Task<HttpResponseMessage> GetAsync(string uri);
 
         /// <summary>
         /// Performs an HTTP POST with the passed URL command.
         /// </summary>
         /// <param name="command">URL command for POST operation</param>
         /// <returns>String response such as JSON or XML</returns>
-        Task<string> PostAsync(string uri);
+        Task<HttpResponseMessage> PostAsync(string uri);
     }
 }

--- a/SteamWebAPI2/Utilities/ISteamWebInterface.cs
+++ b/SteamWebAPI2/Utilities/ISteamWebInterface.cs
@@ -13,7 +13,7 @@ namespace SteamWebAPI2.Utilities
         /// <param name="version">The version of the method to call</param>
         /// <param name="parameters">An optional list of parameters to include with the call</param>
         /// <returns></returns>
-        Task<T> GetAsync<T>(string methodName, int version, IList<SteamWebRequestParameter> parameters = null);
+        Task<ISteamWebResponse<T>> GetAsync<T>(string methodName, int version, IList<SteamWebRequestParameter> parameters = null);
 
         /// <summary>
         /// Calls a specific POST method on whatever interface this class represents. For example "IsPlayingSharedGame" is a method on the "PlayerService" web interface.
@@ -23,6 +23,6 @@ namespace SteamWebAPI2.Utilities
         /// <param name="version">The version of the method to call</param>
         /// <param name="parameters">An optional list of parameters to include with the call</param>
         /// <returns></returns>
-        Task<T> PostAsync<T>(string methodName, int version, IList<SteamWebRequestParameter> parameters = null);
+        Task<ISteamWebResponse<T>> PostAsync<T>(string methodName, int version, IList<SteamWebRequestParameter> parameters = null);
     }
 }

--- a/SteamWebAPI2/Utilities/ISteamWebRequest.cs
+++ b/SteamWebAPI2/Utilities/ISteamWebRequest.cs
@@ -14,7 +14,7 @@ namespace SteamWebAPI2.Utilities
         /// <param name="methodVersion">Name of web API method version</param>
         /// <param name="parameters">List of parameters to append to the web API call</param>
         /// <returns>Deserialized object from JSON response</returns>
-        Task<T> GetAsync<T>(string interfaceName, string methodName, int methodVersion, IList<SteamWebRequestParameter> parameters = null);
+        Task<ISteamWebResponse<T>> GetAsync<T>(string interfaceName, string methodName, int methodVersion, IList<SteamWebRequestParameter> parameters = null);
 
         /// <summary>
         /// Performs a POST request to the provided interface, method, and version with the passed parameters
@@ -25,6 +25,6 @@ namespace SteamWebAPI2.Utilities
         /// <param name="methodVersion">Name of web API method version</param>
         /// <param name="parameters">List of parameters to append to the web API call</param>
         /// <returns>Deserialized object from JSON response</returns>
-        Task<T> PostAsync<T>(string interfaceName, string methodName, int methodVersion, IList<SteamWebRequestParameter> parameters = null);
+        Task<ISteamWebResponse<T>> PostAsync<T>(string interfaceName, string methodName, int methodVersion, IList<SteamWebRequestParameter> parameters = null);
     }
 }

--- a/SteamWebAPI2/Utilities/ISteamWebResponse.cs
+++ b/SteamWebAPI2/Utilities/ISteamWebResponse.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace SteamWebAPI2.Utilities
+{
+    public interface ISteamWebResponse<T>
+    {
+        T Data { get; set; }
+        long? ContentLength { get; set; }
+        string ContentType { get; set; }
+        string ContentTypeCharSet { get; set; }
+        DateTimeOffset? Expires { get; set; }
+        DateTimeOffset? LastModified { get; set; }
+    }
+}

--- a/SteamWebAPI2/Utilities/SteamWebInterface.cs
+++ b/SteamWebAPI2/Utilities/SteamWebInterface.cs
@@ -72,7 +72,7 @@ namespace SteamWebAPI2.Utilities
         /// <param name="version">The version of the method to call</param>
         /// <param name="parameters">An optional list of parameters to include with the call</param>
         /// <returns></returns>
-        public async Task<T> GetAsync<T>(string methodName, int version, IList<SteamWebRequestParameter> parameters = null)
+        public async Task<ISteamWebResponse<T>> GetAsync<T>(string methodName, int version, IList<SteamWebRequestParameter> parameters = null)
         {
             Debug.Assert(!String.IsNullOrWhiteSpace(methodName));
             Debug.Assert(version > 0);
@@ -88,7 +88,7 @@ namespace SteamWebAPI2.Utilities
         /// <param name="version">The version of the method to call</param>
         /// <param name="parameters">An optional list of parameters to include with the call</param>
         /// <returns></returns>
-        public async Task<T> PostAsync<T>(string methodName, int version, IList<SteamWebRequestParameter> parameters = null)
+        public async Task<ISteamWebResponse<T>> PostAsync<T>(string methodName, int version, IList<SteamWebRequestParameter> parameters = null)
         {
             Debug.Assert(!String.IsNullOrWhiteSpace(methodName));
             Debug.Assert(version > 0);

--- a/SteamWebAPI2/Utilities/SteamWebResponse.cs
+++ b/SteamWebAPI2/Utilities/SteamWebResponse.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace SteamWebAPI2.Utilities
+{
+    public class SteamWebResponse<T> : ISteamWebResponse<T>
+    {
+        public T Data { get; set; }
+        public long? ContentLength { get; set; }
+        public string ContentType { get; set; }
+        public string ContentTypeCharSet { get; set; }
+        public DateTimeOffset? Expires { get; set; }
+        public DateTimeOffset? LastModified { get; set; }
+    }
+}

--- a/SteamWebAPI2/packages.config
+++ b/SteamWebAPI2/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoMapper" version="4.2.1" targetFramework="net46" />
+  <package id="AutoMapper" version="5.2.0" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
   <package id="Steam.Models" version="2.0.0.3" targetFramework="net46" />
 </packages>

--- a/SteamWebAPI2/packages.config
+++ b/SteamWebAPI2/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="AutoMapper" version="4.2.1" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
-  <package id="Steam.Models" version="2.0.0.2" targetFramework="net46" />
+  <package id="Steam.Models" version="2.0.0.3" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
This adds support for viewing HTTP headers in the response of every endpoint. I've implemented in such a way as to be "agnostic" to HTTP. Instead of returning an HttpResponseMessage directly, I abstract that away using a SteamWebResponse object.

I've also adjusted auto mappings, unit tests, and comments based on the changes.