### PR TITLE
Added GetSchemaForTF2Async to IEconItems

### DIFF
--- a/src/SteamWebAPI2/Interfaces/IEconItems.cs
+++ b/src/SteamWebAPI2/Interfaces/IEconItems.cs
@@ -10,6 +10,8 @@ namespace SteamWebAPI2.Interfaces
         Task<ISteamWebResponse<EconItemResultModel>> GetPlayerItemsAsync(ulong steamId);
 
         Task<ISteamWebResponse<Steam.Models.DOTA2.SchemaModel>> GetSchemaAsync(string language = "en_us");
+        
+        Task<ISteamWebResponse<Steam.Models.TF2.SchemaModel>> GetSchemaForTF2Async(string language = "en_us");
 
         Task<ISteamWebResponse<string>> GetSchemaUrlAsync();
 


### PR DESCRIPTION
This PR just adds GetSchemaForTF2Async to the IEconItems interface. The EconItems class already implements it.