### PR TITLE
Added Support for the GetPublishedFileDetails Endpoint.

### DIFF
--- a/src/SteamWebAPI2/AutoMapperConfiguration.cs
+++ b/src/SteamWebAPI2/AutoMapperConfiguration.cs
@@ -109,6 +109,7 @@ namespace SteamWebAPI2
                     CreateSteamWebResponseMap<AssetPriceResultContainer, AssetPriceResultModel>(x);
                     CreateSteamWebResponseMap<SteamNewsResultContainer, SteamNewsResultModel>(x);
                     CreateSteamWebResponseMap<PublishedFileDetailsResultContainer, IReadOnlyCollection<PublishedFileDetailsModel>>(x);
+                    CreateSteamWebResponseMap<PublishedFileDetailsResultContainer, PublishedFileDetailsModel>(x);
                     CreateSteamWebResponseMap<UGCFileDetailsResultContainer, UGCFileDetailsModel>(x);
                     CreateSteamWebResponseMap<PlayerSummaryResultContainer, PlayerSummaryModel>(x);
                     CreateSteamWebResponseMap<PlayerSummaryResultContainer, IReadOnlyCollection<PlayerSummaryModel>>(x);
@@ -382,12 +383,19 @@ namespace SteamWebAPI2
                     #region Endpoint: SteamRemoteStorage
 
                     x.CreateMap<uint, PublishedFileVisibility>();
-                    x.CreateMap<PublishedFileDetails, PublishedFileDetailsModel>();
+                    x.CreateMap<PublishedFileDetails, PublishedFileDetailsModel>()
+                        .ForMember(dest => dest.FileUrl, opts => opts.MapFrom(source => new Uri(source.FileUrl)))
+                        .ForMember(dest => dest.PreviewUrl, opts => opts.MapFrom(source => new Uri(source.PreviewUrl)));
                     x.CreateMap<PublishedFileDetailsResultContainer, IReadOnlyCollection<PublishedFileDetailsModel>>()
                         .ConvertUsing(
                             src => Mapper.Map<IList<PublishedFileDetails>, IReadOnlyCollection<PublishedFileDetailsModel>>(
-                                src.Result != null && src.Result.Result == 1 ? src.Result.Details : null)
+                                src.Result?.Result == 1 ? src.Result.Details : null)
                     );
+                    x.CreateMap<PublishedFileDetailsResultContainer, PublishedFileDetailsModel>()
+                        .ConvertUsing(
+                            src => Mapper.Map<PublishedFileDetails, PublishedFileDetailsModel>(
+                                src.Result?.Result == 1 ? src.Result.Details?.SingleOrDefault() : null)
+                        );
 
                     x.CreateMap<UGCFileDetails, UGCFileDetailsModel>();
                     x.CreateMap<UGCFileDetailsResultContainer, UGCFileDetailsModel>().ConvertUsing(

--- a/src/SteamWebAPI2/AutoMapperConfiguration.cs
+++ b/src/SteamWebAPI2/AutoMapperConfiguration.cs
@@ -108,6 +108,7 @@ namespace SteamWebAPI2
                     CreateSteamWebResponseMap<AssetClassInfoResultContainer, AssetClassInfoResultModel>(x);
                     CreateSteamWebResponseMap<AssetPriceResultContainer, AssetPriceResultModel>(x);
                     CreateSteamWebResponseMap<SteamNewsResultContainer, SteamNewsResultModel>(x);
+                    CreateSteamWebResponseMap<PublishedFileDetailsResultContainer, IReadOnlyCollection<PublishedFileDetailsModel>>(x);
                     CreateSteamWebResponseMap<UGCFileDetailsResultContainer, UGCFileDetailsModel>(x);
                     CreateSteamWebResponseMap<PlayerSummaryResultContainer, PlayerSummaryModel>(x);
                     CreateSteamWebResponseMap<PlayerSummaryResultContainer, IReadOnlyCollection<PlayerSummaryModel>>(x);
@@ -379,6 +380,14 @@ namespace SteamWebAPI2
                     #endregion
 
                     #region Endpoint: SteamRemoteStorage
+
+                    x.CreateMap<uint, PublishedFileVisibility>();
+                    x.CreateMap<PublishedFileDetails, PublishedFileDetailsModel>();
+                    x.CreateMap<PublishedFileDetailsResultContainer, IReadOnlyCollection<PublishedFileDetailsModel>>()
+                        .ConvertUsing(
+                            src => Mapper.Map<IList<PublishedFileDetails>, IReadOnlyCollection<PublishedFileDetailsModel>>(
+                                src.Result != null && src.Result.Result == 1 ? src.Result.Details : null)
+                    );
 
                     x.CreateMap<UGCFileDetails, UGCFileDetailsModel>();
                     x.CreateMap<UGCFileDetailsResultContainer, UGCFileDetailsModel>().ConvertUsing(

--- a/src/SteamWebAPI2/Interfaces/ISteamRemoteStorage.cs
+++ b/src/SteamWebAPI2/Interfaces/ISteamRemoteStorage.cs
@@ -4,8 +4,12 @@ using System.Threading.Tasks;
 
 namespace SteamWebAPI2.Interfaces
 {
+    using System.Collections.Generic;
+
     public interface ISteamRemoteStorage
     {
+        Task<ISteamWebResponse<IReadOnlyCollection<PublishedFileDetailsModel>>> GetPublishedFileDetailsAsync(uint itemCount, IList<ulong> publishedFileIds);
+
         Task<ISteamWebResponse<UGCFileDetailsModel>> GetUGCFileDetailsAsync(ulong ugcId, uint appId, ulong? steamId = null);
     }
 }

--- a/src/SteamWebAPI2/Interfaces/ISteamRemoteStorage.cs
+++ b/src/SteamWebAPI2/Interfaces/ISteamRemoteStorage.cs
@@ -10,6 +10,10 @@ namespace SteamWebAPI2.Interfaces
     {
         Task<ISteamWebResponse<IReadOnlyCollection<PublishedFileDetailsModel>>> GetPublishedFileDetailsAsync(uint itemCount, IList<ulong> publishedFileIds);
 
+        Task<ISteamWebResponse<IReadOnlyCollection<PublishedFileDetailsModel>>> GetPublishedFileDetailsAsync(IList<ulong> publishedFileIds);
+
+        Task<ISteamWebResponse<PublishedFileDetailsModel>> GetPublishedFileDetailsAsync(ulong publishedFileId);
+
         Task<ISteamWebResponse<UGCFileDetailsModel>> GetUGCFileDetailsAsync(ulong ugcId, uint appId, ulong? steamId = null);
     }
 }

--- a/src/SteamWebAPI2/Interfaces/SteamRemoteStorage.cs
+++ b/src/SteamWebAPI2/Interfaces/SteamRemoteStorage.cs
@@ -1,8 +1,10 @@
 ﻿using Steam.Models;
 using SteamWebAPI2.Models;
 using SteamWebAPI2.Utilities;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -28,10 +30,25 @@ namespace SteamWebAPI2.Interfaces
         /// </summary>
         /// <param name="itemCount">The quantity of items for which to retrieve details.
         /// This can be smaller than the amount of items in <paramref name="publishedFileIds"/>, but not larger.</param>
-        /// <param name="publishedFileIds">The list of ids of files for which to retrieve details.</param>
-        /// <returns>A collection of the details of the files or <c>null</c> if the request failed.</returns>
+        /// <param name="publishedFileIds">The list of IDs of files for which to retrieve details.</param>
+        /// <returns>A collection of the details of each file or <c>null</c> if the request failed.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="publishedFileIds"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="publishedFileIds"/> is empty or <paramref name="itemCount"/>is greater than the number of elements in <paramref name="publishedFileIds"/>.</exception>
         public async Task<ISteamWebResponse<IReadOnlyCollection<PublishedFileDetailsModel>>> GetPublishedFileDetailsAsync(uint itemCount, IList<ulong> publishedFileIds) {
-            Debug.Assert(itemCount <= publishedFileIds.Count);
+            if (publishedFileIds == null)
+            {
+                throw new ArgumentNullException(nameof(publishedFileIds));
+            }
+
+            if (!publishedFileIds.Any())
+            {
+                throw new ArgumentOutOfRangeException(nameof(publishedFileIds), $"{nameof(publishedFileIds)} is empty.");
+            }
+
+            if (itemCount > publishedFileIds.Count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(itemCount), itemCount, $"{nameof(itemCount)} cannot be greater than the number of elements in {nameof(publishedFileIds)}.");
+            }
 
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
             parameters.AddIfHasValue(itemCount, "itemcount");
@@ -41,20 +58,39 @@ namespace SteamWebAPI2.Interfaces
                 parameters.AddIfHasValue(publishedFileIds[i], $"publishedfileids[{i}]");
             }
 
-            try
-            {
-                var steamWebResponse = await steamWebInterface.PostAsync<PublishedFileDetailsResultContainer>("GetPublishedFileDetails", 1, parameters);
+            return await GetPublishedFileDetailsAsync<IReadOnlyCollection<PublishedFileDetailsModel>>(parameters);
+        }
 
-                var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
-                    ISteamWebResponse<PublishedFileDetailsResultContainer>,
-                    ISteamWebResponse<IReadOnlyCollection<PublishedFileDetailsModel>>>(steamWebResponse);
-
-                return steamWebResponseModel;
-            }
-            catch (HttpRequestException)
+        /// <summary>
+        /// Retrieves information about published files such as workshop items and screenshots.
+        /// </summary>
+        /// <param name="publishedFileIds">The list of IDs of files for which to retrieve details.</param>
+        /// <returns>A collection of the details of each file or <c>null</c> if the request failed.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="publishedFileIds"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="publishedFileIds"/> is empty.</exception>
+        public async Task<ISteamWebResponse<IReadOnlyCollection<PublishedFileDetailsModel>>> GetPublishedFileDetailsAsync(IList<ulong> publishedFileIds)
+        {
+            if (publishedFileIds == null)
             {
-                return null;
+                throw new ArgumentNullException(nameof(publishedFileIds));
             }
+
+            return await GetPublishedFileDetailsAsync((uint)publishedFileIds.Count, publishedFileIds);
+        }
+
+        /// <summary>
+        /// Retrieves information about a published file such as a workshop item or screenshot.
+        /// </summary>
+        /// <param name="publishedFileId">The ID of the file for which to retrieve details.</param>
+        /// <returns>The details of the file or <c>null</c> if the request failed.</returns>
+        public async Task<ISteamWebResponse<PublishedFileDetailsModel>> GetPublishedFileDetailsAsync(ulong publishedFileId)
+        {
+            List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
+
+            parameters.AddIfHasValue(1, "itemcount");
+            parameters.AddIfHasValue(publishedFileId, "publishedfileids[0]");
+
+            return await GetPublishedFileDetailsAsync<PublishedFileDetailsModel>(parameters);
         }
 
         /// <summary>
@@ -81,6 +117,29 @@ namespace SteamWebAPI2.Interfaces
                 var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
                     ISteamWebResponse<UGCFileDetailsResultContainer>,
                     ISteamWebResponse<UGCFileDetailsModel>>(steamWebResponse);
+
+                return steamWebResponseModel;
+            }
+            catch (HttpRequestException)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Sends a request to GetPublishedFileDetails and maps the response's data to <typeparamref name="TData"/>.
+        /// </summary>
+        /// <typeparam name="TData">The type to which to map the data of the response.</typeparam>
+        /// <param name="parameters">The parameters of the request.</param>
+        /// <returns>The response of the request to the API or <c>null</c> if the request failed.</returns>
+        private async Task<ISteamWebResponse<TData>> GetPublishedFileDetailsAsync<TData>(IList<SteamWebRequestParameter> parameters) {
+            try
+            {
+                var steamWebResponse = await steamWebInterface.PostAsync<PublishedFileDetailsResultContainer>("GetPublishedFileDetails", 1, parameters);
+
+                var steamWebResponseModel = AutoMapperConfiguration.Mapper.Map<
+                    ISteamWebResponse<PublishedFileDetailsResultContainer>,
+                    ISteamWebResponse<TData>>(steamWebResponse);
 
                 return steamWebResponseModel;
             }

--- a/src/SteamWebAPI2/Models/PublishedFileDetailsResultContainer.cs
+++ b/src/SteamWebAPI2/Models/PublishedFileDetailsResultContainer.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Newtonsoft.Json;
+
+namespace SteamWebAPI2.Models
+{
+    using SteamWebAPI2.Utilities.JsonConverters;
+
+    internal class PublishedFileDetailsResultContainer
+    {
+        [JsonProperty("response")]
+        public PublishedFileDetailsResult Result { get; set; }
+    }
+
+    internal class PublishedFileDetailsResult
+    {
+        [JsonProperty("result")]
+        public uint Result { get; set; }
+
+        [JsonProperty("resultcount")]
+        public uint Count { get; set; }
+
+        [JsonProperty("publishedfiledetails")]
+        public IList<PublishedFileDetails> Details { get; set; }
+    }
+
+    internal class PublishedFileDetails
+    {
+        [JsonProperty("publishedfileid")]
+        public ulong PublishedFileId { get; set; }
+
+        [JsonProperty("result")]
+        public uint Result { get; set; }
+
+        [JsonProperty("creator")]
+        public ulong Creator { get; set; }
+
+        [JsonProperty("creator_app_id")]
+        public uint CreatorAppId { get; set; }
+
+        [JsonProperty("consumer_app_id")]
+        public uint ConsumerAppId { get; set; }
+
+        [JsonProperty("filename")]
+        public string FileName { get; set; }
+
+        [JsonProperty("file_size")]
+        public uint FileSize { get; set; }
+
+        [JsonProperty("file_url")]
+        public string FileUrl { get; set; }
+
+        [JsonProperty("hcontent_file")]
+        public ulong FileContentHandle { get; set; }
+
+        [JsonProperty("preview_url")]
+        public string PreviewUrl { get; set; }
+
+        [JsonProperty("hcontent_preview")]
+        public ulong PreviewContentHandle { get; set; }
+
+        [JsonProperty("title")]
+        public string Title { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("time_created")]
+        [JsonConverter(typeof(UnixTimeJsonConverter))]
+        public DateTime TimeCreated { get; set; }
+
+        [JsonProperty("time_updated")]
+        [JsonConverter(typeof(UnixTimeJsonConverter))]
+        public DateTime TimeUpdated { get; set; }
+
+        [JsonProperty("visibility")]
+        public uint Visibility { get; set; }
+
+        [JsonProperty("banned")]
+        public bool Banned { get; set; }
+
+        [JsonProperty("ban_reason")]
+        public string BanReason { get; set; }
+
+        [JsonProperty("subscriptions")]
+        public ulong Subscriptions { get; set; }
+
+        [JsonProperty("favorited")]
+        public ulong Favorited { get; set; }
+
+        [JsonProperty("lifetime_subscriptions")]
+        public ulong LifetimeSubscriptions { get; set; }
+
+        [JsonProperty("lifetime_favorited")]
+        public ulong LifetimeFavorited { get; set; }
+
+        [JsonProperty("views")]
+        public ulong Views { get; set; }
+
+        [JsonProperty("tags")]
+        [JsonConverter(typeof(TagsJsonConverter))]
+        public IList<string> Tags { get; set; }
+    }
+}

--- a/src/SteamWebAPI2/SteamWebAPI2.csproj
+++ b/src/SteamWebAPI2/SteamWebAPI2.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="automapper" Version="6.1.1" />
     <PackageReference Include="newtonsoft.json" Version="10.0.3" />
-    <PackageReference Include="Steam.Models" Version="3.0.4" />
+    <PackageReference Include="Steam.Models" Version="3.0.6" />
   </ItemGroup>
 
 </Project>

--- a/src/SteamWebAPI2/Utilities/ISteamWebHttpClient.cs
+++ b/src/SteamWebAPI2/Utilities/ISteamWebHttpClient.cs
@@ -8,15 +8,16 @@ namespace SteamWebAPI2.Utilities
         /// <summary>
         /// Performs an HTTP GET with the passed URL command.
         /// </summary>
-        /// <param name="command">URL command for GET operation</param>
+        /// <param name="uri">URL command for GET operation</param>
         /// <returns>String response such as JSON or XML</returns>
         Task<HttpResponseMessage> GetAsync(string uri);
 
         /// <summary>
         /// Performs an HTTP POST with the passed URL command.
         /// </summary>
-        /// <param name="command">URL command for POST operation</param>
+        /// <param name="uri">URL command for POST operation</param>
+        /// <param name="content">The HTTP request content sent to the server.</param>
         /// <returns>String response such as JSON or XML</returns>
-        Task<HttpResponseMessage> PostAsync(string uri);
+        Task<HttpResponseMessage> PostAsync(string uri, HttpContent content);
     }
 }

--- a/src/SteamWebAPI2/Utilities/JsonConverters/TagsJsonConverter.cs
+++ b/src/SteamWebAPI2/Utilities/JsonConverters/TagsJsonConverter.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using Newtonsoft.Json;
+
+namespace SteamWebAPI2.Utilities.JsonConverters
+{
+    /// <inheritdoc />
+    /// <summary>
+    /// Converts the tags stored in a list of dictionaries to a list of the values of the dictionary.
+    /// <remarks>The keys seem to always be the string "tag".</remarks>
+    /// </summary>
+    internal class TagsJsonConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var original = serializer.Deserialize<List<Dictionary<string, string>>>(reader);
+            var tags = new List<string>();
+
+            original.ForEach(tag => tags.AddRange(tag.Values));
+
+            return tags;
+        }
+
+        public override bool CanWrite => false;
+
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(IList<IDictionary<string, string>>).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
+        }
+    }
+}

--- a/src/SteamWebAPI2/Utilities/SteamWebHttpClient.cs
+++ b/src/SteamWebAPI2/Utilities/SteamWebHttpClient.cs
@@ -38,15 +38,16 @@ namespace SteamWebAPI2.Utilities
         /// Performs an HTTP POST with the passed URL command.
         /// </summary>
         /// <param name="command">URL command for POST operation</param>
+        /// <param name="content">The HTTP request content sent to the server.</param>
         /// <returns>String response such as JSON or XML</returns>
-        public async Task<HttpResponseMessage> PostAsync(string command)
+        public async Task<HttpResponseMessage> PostAsync(string command, HttpContent content)
         {
             Debug.Assert(!String.IsNullOrWhiteSpace(command));
 
             HttpClient httpClient = new HttpClient();
 
-            var response = await httpClient.PostAsync(command, null);
-            
+            var response = await httpClient.PostAsync(command, content);
+
             response.EnsureSuccessStatusCode();
 
             if (response.Content == null)


### PR DESCRIPTION
[Here](https://partner.steamgames.com/doc/webapi/ISteamRemoteStorage#GetPublishedFileDetails) is Steam's documentation of the endpoint. Example responses are shown at the end.

These changes depend on the existence of `PublishedFileDetailsModel` and `PublishedFileVisibility` in Steam.Models. They have been added in babelshift/Steam.Models#8. The version of the NuGet package dependency has not been changed.

I hope the commit messages and diffs are enough of a description of the changes. Instead, I will discuss some concerns I have with my implementation.

* Should the tags be converted to a more sensible format as I have done, or should closely matching Steam's response be maintained?
* Possibly add overloads of `GetPublishedFileDetailsAsync`.
    * One which infers `itemcount` from the size of `publishedFileIds`. Alternatively, it could be made an optional argument. In that case, it would make the most sense for the default to be 0.
    * One which takes only one ID and returns a single object instead of a list.
* In reference to `result` in an object in `publishedfiledetails`, how should unsuccessful results be handled? Currently, most properties will be `null` on failure, but this isn't transparent to the client. I'm inclined to leave it as is because, based on what I have seen from the rest of the design, this wrapper does not seem to concern itself with notifying the client of failure. The only way in which this is done is though returning `null`.<br/><br/>That being said, here are some options (not mutually exclusive):
    * Make it the client's responsibility to check `result` for success.
        * Many would probably learn the hard way as the only documentation on this would be just an additional line or two in `GetPublishedFileDetailsAsync`'s summary.
    * Add the [`EResult`](https://partner.steamgames.com/doc/api/steam_api#EResult) enum to System.Models and map `result` to it.
    * When mapping types, remove any unsuccessful results from the list.
    * Add a member function to `PublishedFileDetailsModel` which returns a boolean indicative of the success of retrieving the details for that instance of the object.

Example of a failed response (file was not found):

```json
{
    "response": {
        "result": 1,
        "resultcount": 1,
        "publishedfiledetails": [
            {
                "publishedfileid": "14672664",
                "result": 9
            }
        ]
    }
}
```

Example of a successful response:

```json
{
    "response": {
        "result": 1,
        "resultcount": 1,
        "publishedfiledetails": [
            {
                "publishedfileid": "243702660",
                "result": 1,
                "creator": "76561197970363778",
                "creator_app_id": 730,
                "consumer_app_id": 730,
                "filename": "mymaps/aim_botz.bsp",
                "file_size": 9370901,
                "file_url": "http://cloud-3.steamusercontent.com/ugc/856102160281273455/FDBCBDE6628DD013B646902A4152E1C1DC8D08AB/",
                "hcontent_file": "856102160281273455",
                "preview_url": "https://steamuserimages-a.akamaihd.net/ugc/436073278216348686/16A15AD676BC843C85665CD3E71EBBAFA660BFF0/",
                "hcontent_preview": "436073278216348686",
                "title": "Aim Botz - Training",
                "description": "[url=https://www.youtube.com/c/uLLeticaL][img]http://i.imgur.com/BzkzLBk.png?soc1[/img][/url][url=https://twitter.com/uLLeticaL][img]http://imgur.com/TbFvzYW.png?soc1[/img][/url][url=http://steamcommunity.com/groups/uLLeticaL][img]http://i.imgur.com/leoC38K.gif?soc3[/img][/url][url=http://steamcommunity.com/groups/uLLeticaL][img]http://i.imgur.com/GQ4Voen.png?soc4[/img][/url][url=http://steamcommunity.com/id/uLLeticaL/myworkshopfiles/?appid=730&sort=score&browsefilter=myfiles][img]http://i.imgur.com/VVBt4Aj.png?soc5[/img][/url]\r\n\r\n[url=http://steamcommunity.com/groups/uLLeticaL/discussions/0/618460171326407370#forum_op_618460171326407370][img]http://i.imgur.com/Rd0cC2W.png?tdhead[/img][/url]\r\n[url=http://steamcommunity.com/groups/uLLeticaL/discussions/0/618460171326407370#forum_op_618460171326407370][img]http://ulletical.com/_workshop/gfx/donators.png[/img][/url]\r\n[img]http://i.imgur.com/uWU3h0A.png?hr[/img]\r\n[url=http://steamcommunity.com/groups/uLLeticaL/discussions/0/618460171326407370#forum_op_618460171326407370][img]http://i.imgur.com/lAZUQ2Z.gif?supate[/img][/url]\r\n[img]http://i.imgur.com/uWU3h0A.png?hr[/img]\r\n\r\n[h1][b]Aim Training Map with Bots.[/b][/h1]\r\nRelease your inner 360 aimbot and keep on shooting those headshots all around you.\r\n\r\n[h1][b]Useful Links[/b][/h1][list]\r\n[*][url=http://steamcommunity.com/workshop/filedetails/discussion/243702660/530646080845617098/]Help & FAQ[/url]\r\n[*][url=http://steamcommunity.com/workshop/filedetails/discussion/243702660/616189742971268102/]Feedback & Bug Reports[/url]\r\n[*][url=https://youtu.be/9hHHVLnazlI]How to [u]Download[/u] the map?[/url]\r\n[/list]\r\n\r\n[h1][b]Key Features[/b][/h1][list]\r\n[*]Moving bots, you can turn this on or off.\r\n[*]Enable or disable kevlar+helmet on bots.\r\n[*]Peek/spray walls, to practice peeking shots.\r\n[*]Enable or disable unlimited ammo, to your liking.\r\n[*]Sound practice test, a target pops up somewhere with a fire sound.\r\n[*]All weapons available, just press or shoot the buttons to receive the weapon.\r\n[*]Enable or disable sections of the map, through the green or red buttons on the ceiling.\r\n[/list]\r\n\r\n[img]http://i.imgur.com/uWU3h0A.png?hr[/img]\r\n[img]http://www.ulletical.com/statistics/piwik.php?idsite=7&rec=1[/img]\r\n[img]http://i.imgur.com/yGF9y9Q.png?thanks[/img]\r\n\r\n[quote]Search Tags: [i]Ausbildung, Entraînement, Обучение, Träning, Opplæring, トレーニング, Entrenamiento, Formazione, Szkolenie, Výcvik, Praxis, Pratique, Практика, Praxis, Praksis, 練習, 目标, 实践, 實踐, 納伊姆實踐, 纳伊姆实践, Práctica, Pratica, Praktyka, Praxe, trening map, trening[/i][/quote]\r\n\r\n[url=https://youtu.be/9hHHVLnazlI][img]http://i.imgur.com/gQfWPLT.gif?help[/img][/url]\r\n© 2017 uLLeticaL.com",
                "time_created": 1396126087,
                "time_updated": 1503426221,
                "visibility": 0,
                "banned": 0,
                "ban_reason": "",
                "subscriptions": 6372773,
                "favorited": 71459,
                "lifetime_subscriptions": 6688259,
                "lifetime_favorited": 75107,
                "views": 4510272,
                "tags": [
                    {
                        "tag": "Custom"
                    },
                    {
                        "tag": "Training"
                    },
                    {
                        "tag": "Map"
                    }
                ]           
            }
        ]      
    }
}
```