### PR TITLE
Fixed JsonReaderException when Stat.DefaultValue exceeds int value range

### DIFF
--- a/src/SteamWebAPI2/Models/SchemaForGameResultContainer.cs
+++ b/src/SteamWebAPI2/Models/SchemaForGameResultContainer.cs
@@ -9,7 +9,7 @@ namespace SteamWebAPI2.Models
         public string Name { get; set; }
 
         [JsonProperty("defaultvalue")]
-        public int DefaultValue { get; set; }
+        public long DefaultValue { get; set; }
 
         [JsonProperty("displayName")]
         public string DisplayName { get; set; }
@@ -21,7 +21,7 @@ namespace SteamWebAPI2.Models
         public string Name { get; set; }
 
         [JsonProperty("defaultvalue")]
-        public int DefaultValue { get; set; }
+        public long DefaultValue { get; set; }
 
         [JsonProperty("displayName")]
         public string DisplayName { get; set; }


### PR DESCRIPTION
Should fix #60 by extending the type for both `DefaultValue` properties in stats to `long`