### PR TITLE
Updated Newtonsoft and AutoMapper to the latest versions

### DIFF
--- a/src/SteamWebAPI2/SteamWebAPI2.csproj
+++ b/src/SteamWebAPI2/SteamWebAPI2.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="automapper" Version="6.1.1" />
-    <PackageReference Include="newtonsoft.json" Version="10.0.3" />
+    <PackageReference Include="automapper" Version="8.0.0" />
+    <PackageReference Include="newtonsoft.json" Version="12.0.1" />
     <PackageReference Include="Steam.Models" Version="3.0.8" />
   </ItemGroup>
 


### PR DESCRIPTION
The latest version of AutoMapper(8.0.0) has some issues with the currently used version