### PR TITLE
add short description and price overview to app details data

### DIFF
--- a/src/SteamWebAPI2/AutoMapperConfiguration.cs
+++ b/src/SteamWebAPI2/AutoMapperConfiguration.cs
@@ -579,6 +579,7 @@ namespace SteamWebAPI2
                     x.CreateMap<Metacritic, StoreMetacriticModel>();
                     x.CreateMap<Platforms, StorePlatformsModel>();
                     x.CreateMap<PackageGroup, StorePackageGroupModel>();
+                    x.CreateMap<Price, StorePriceOverview>();
                     x.CreateMap<Sub, StoreSubModel>();
 
                     x.CreateMap<FeaturedCategoriesContainer, StoreFeaturedCategoriesModel>();

--- a/src/SteamWebAPI2/Interfaces/SteamStore.cs
+++ b/src/SteamWebAPI2/Interfaces/SteamStore.cs
@@ -2,12 +2,21 @@
 using SteamWebAPI2.Models.SteamStore;
 using SteamWebAPI2.Utilities;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace SteamWebAPI2.Interfaces
 {
     public class SteamStore : SteamStoreInterface, ISteamStore
     {
+        public SteamStore() : base()
+        {
+        }
+
+        public SteamStore(HttpClient httpClient) : base(httpClient)
+        {
+        }
+
         /// <summary>
         /// Maps to the steam store api endpoint: GET http://store.steampowered.com/api/appdetails/
         /// </summary>

--- a/src/SteamWebAPI2/Models/SteamStore/AppDetailsContainer.cs
+++ b/src/SteamWebAPI2/Models/SteamStore/AppDetailsContainer.cs
@@ -159,6 +159,27 @@ namespace SteamWebAPI2.Models.SteamStore
         public string Email { get; set; }
     }
 
+    internal class Price
+    {
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        [JsonProperty("initial")]
+        public uint Initial { get; set; }
+
+        [JsonProperty("final")]
+        public uint Final { get; set; }
+
+        [JsonProperty("discount_percent")]
+        public uint DiscountPercent { get; set; }
+
+        [JsonProperty("initial_formatted")]
+        public string InitialFormatted { get; set; }
+
+        [JsonProperty("final_formatted")]
+        public string FinalFormatted { get; set; }
+    }
+
     internal class Data
     {
         [JsonProperty("type")]
@@ -205,6 +226,9 @@ namespace SteamWebAPI2.Models.SteamStore
 
         [JsonProperty("developers")]
         public string[] Developers { get; set; }
+
+        [JsonProperty("price_overview")]
+        public Price PriceOverview { get; set; }
 
         [JsonProperty("publishers")]
         public string[] Publishers { get; set; }

--- a/src/SteamWebAPI2/Models/SteamStore/AppDetailsContainer.cs
+++ b/src/SteamWebAPI2/Models/SteamStore/AppDetailsContainer.cs
@@ -206,6 +206,9 @@ namespace SteamWebAPI2.Models.SteamStore
         [JsonProperty("about_the_game")]
         public string AboutTheGame { get; set; }
 
+        [JsonProperty("short_description")]
+        public string ShortDescription { get; set; }
+
         [JsonProperty("supported_languages")]
         public string SupportedLanguages { get; set; }
 

--- a/src/SteamWebAPI2/SteamStoreInterface.cs
+++ b/src/SteamWebAPI2/SteamStoreInterface.cs
@@ -2,8 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace SteamWebAPI2
@@ -15,7 +14,7 @@ namespace SteamWebAPI2
     {
         private const string steamStoreApiBaseUrl = "http://store.steampowered.com/api/";
         private readonly SteamStoreRequest steamStoreRequest;
-        
+
         /// <summary>
         /// Constructs and maps the default objects for Steam Store Web API use
         /// </summary>
@@ -27,12 +26,35 @@ namespace SteamWebAPI2
         }
 
         /// <summary>
+        /// Constructs and maps based on a custom http client
+        /// </summary>
+        /// <param name="httpClient">Client to make requests with</param>
+        public SteamStoreInterface(HttpClient httpClient)
+        {
+            this.steamStoreRequest = new SteamStoreRequest(steamStoreApiBaseUrl, httpClient);
+
+            AutoMapperConfiguration.Initialize();
+        }
+
+        /// <summary>
         /// Constructs and maps based on a custom Steam Store Web API URL
         /// </summary>
         /// <param name="steamStoreApiBaseUrl">Steam Store Web API URL</param>
         public SteamStoreInterface(string steamStoreApiBaseUrl)
         {
             this.steamStoreRequest = new SteamStoreRequest(steamStoreApiBaseUrl);
+
+            AutoMapperConfiguration.Initialize();
+        }
+
+        /// <summary>
+        /// Constructs and maps based on a custom http client and custom Steam Store Web API URL
+        /// </summary>
+        /// <param name="steamStoreApiBaseUrl">Steam Store Web API URL</param>
+        /// <param name="httpClient">Client to make requests with</param>
+        public SteamStoreInterface(string steamStoreApiBaseUrl, HttpClient httpClient)
+        {
+            this.steamStoreRequest = new SteamStoreRequest(steamStoreApiBaseUrl, httpClient);
 
             AutoMapperConfiguration.Initialize();
         }

--- a/src/SteamWebAPI2/SteamStoreRequest.cs
+++ b/src/SteamWebAPI2/SteamStoreRequest.cs
@@ -14,6 +14,7 @@ namespace SteamWebAPI2
     internal class SteamStoreRequest
     {
         private string steamStoreApiBaseUrl;
+        private readonly HttpClient httpClient;
 
         /// <summary>
         /// Constructs a Steam Store Web API request
@@ -27,6 +28,17 @@ namespace SteamWebAPI2
             }
 
             this.steamStoreApiBaseUrl = steamStoreApiBaseUrl;
+        }
+
+        public SteamStoreRequest(string steamStoreApiBaseUrl, HttpClient httpClient)
+        {
+            if (String.IsNullOrEmpty(steamStoreApiBaseUrl))
+            {
+                throw new ArgumentNullException("steamStoreApiBaseUrl");
+            }
+
+            this.steamStoreApiBaseUrl = steamStoreApiBaseUrl;
+            this.httpClient = httpClient;
         }
 
         /// <summary>
@@ -71,10 +83,10 @@ namespace SteamWebAPI2
         /// </summary>
         /// <param name="command">Command (method endpoint) to send to an interface</param>
         /// <returns>HTTP response as a string without tabs and newlines</returns>
-        private static async Task<string> GetHttpStringResponseAsync(string command)
+        private async Task<string> GetHttpStringResponseAsync(string command)
         {
-            HttpClient httpClient = new HttpClient();
-            string response = await httpClient.GetStringAsync(command);
+            HttpClient client = httpClient ?? new HttpClient();
+            string response = await client.GetStringAsync(command);
             response = response.Replace("\n", "");
             response = response.Replace("\t", "");
             return response;

--- a/src/SteamWebAPI2/SteamWebAPI2.csproj
+++ b/src/SteamWebAPI2/SteamWebAPI2.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="automapper" Version="6.1.1" />
     <PackageReference Include="newtonsoft.json" Version="10.0.3" />
-    <PackageReference Include="Steam.Models" Version="3.0.8" />
+    <PackageReference Include="Steam.Models" Version="3.0.10" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I tested, the price overview will come back null if it doesn't exists

This goes with a PR on Steam.Models https://github.com/babelshift/Steam.Models/pull/12