### PR TITLE
Added pagination to EconItems#GetSchemaItemsForTF2Async()

### DIFF
--- a/src/Steam.UnitTests/EconItemsTeamFortress2Tests.cs
+++ b/src/Steam.UnitTests/EconItemsTeamFortress2Tests.cs
@@ -20,9 +20,17 @@ namespace Steam.UnitTests
         [Fact]
         public async Task GetSchemaItemsForTF2Async_Should_Succeed()
         {
-            var response = await steamInterface.GetSchemaItemsForTF2Async();
-            Assert.NotNull(response);
-            Assert.NotNull(response.Data);
+            uint? next = null;
+
+            do
+            {
+                var response = await steamInterface.GetSchemaItemsForTF2Async(start: next);
+                Assert.NotNull(response);
+                Assert.NotNull(response.Data);
+
+                next = response.Data.Result.Next;
+            }
+            while (next.HasValue);
         }
 
         [Fact]

--- a/src/SteamWebAPI2/Interfaces/EconItems.cs
+++ b/src/SteamWebAPI2/Interfaces/EconItems.cs
@@ -81,7 +81,7 @@ namespace SteamWebAPI2.Interfaces
         /// </summary>
         /// <param name="language"></param>
         /// <returns></returns>
-        public async Task<ISteamWebResponse<SchemaItemsResultContainer>> GetSchemaItemsForTF2Async(string language = "en_us")
+        public async Task<ISteamWebResponse<SchemaItemsResultContainer>> GetSchemaItemsForTF2Async(string language = "en_us", uint? start = null)
         {
             if (appId != (int)AppId.TeamFortress2)
             {
@@ -91,6 +91,7 @@ namespace SteamWebAPI2.Interfaces
             List<SteamWebRequestParameter> parameters = new List<SteamWebRequestParameter>();
 
             parameters.AddIfHasValue(language, "language");
+            parameters.AddIfHasValue(start, "start");
 
             var steamWebResponse = await steamWebInterface.GetAsync<SchemaItemsResultContainer>("GetSchemaItems", 1, parameters);
 

--- a/src/SteamWebAPI2/Interfaces/IEconItems.cs
+++ b/src/SteamWebAPI2/Interfaces/IEconItems.cs
@@ -8,7 +8,7 @@ namespace SteamWebAPI2.Interfaces
     {
         Task<ISteamWebResponse<EconItemResultModel>> GetPlayerItemsAsync(ulong steamId);
 
-        Task<ISteamWebResponse<SteamWebAPI2.Models.GameEconomy.SchemaItemsResultContainer>> GetSchemaItemsForTF2Async(string language = "en_us");
+        Task<ISteamWebResponse<SteamWebAPI2.Models.GameEconomy.SchemaItemsResultContainer>> GetSchemaItemsForTF2Async(string language = "en_us", uint? start = null);
 
         Task<ISteamWebResponse<SteamWebAPI2.Models.GameEconomy.SchemaOverviewResultContainer>> GetSchemaOverviewForTF2Async(string language = "en_us");
 

--- a/src/SteamWebAPI2/Models/GameEconomy/SchemaItemResultContainer.cs
+++ b/src/SteamWebAPI2/Models/GameEconomy/SchemaItemResultContainer.cs
@@ -15,7 +15,7 @@ namespace SteamWebAPI2.Models.GameEconomy
         public IList<SchemaItem> Items { get; set; }
 
         [JsonProperty("next")]
-        public uint Next { get; set; }
+        public uint? Next { get; set; }
     }
 
     public class SchemaItemsResultContainer


### PR DESCRIPTION
This fixes issue #104. I thought I'd just get the PR out of the way to save time. Verified with a modified unit test for the method which validates and uses the previously unused Next property in the response from the API.

The changing of `Next` to a `uint?` is a small breaking change, so if it would be preferred to keep it the same type and make other checks internally to know if we're "done" paginating, that could be done too.