### PR TITLE
Add bindings for ISteamRemoteStorage/GetCollectionDetails endpoint.

### DIFF
--- a/src/Steam.Models/CollectionDetailsResponseContainer.cs
+++ b/src/Steam.Models/CollectionDetailsResponseContainer.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+
+namespace Steam.Models
+{
+    public class CollectionDetailsResponseContainer
+    {
+        public CollectionDetailsResponse Response { get; set; }
+    }
+
+    public class CollectionDetailsResponse
+    {
+        public uint Result { get; set; }
+        public uint ResultCount { get; set; }
+        public IList<CollectionDetail> CollectionDetails { get; set; }
+    }
+
+    public class CollectionDetail
+    {
+        public string PublishedFileId { get; set; }
+        public uint Result { get; set; }
+        public IList<CollectionDetailItem> Children { get; set; }
+    }
+
+    public class CollectionDetailItem
+    {
+        public string PublishedFileId { get; set; }
+        public uint SortOrder { get; set; }
+        public uint FileType { get; set; }
+    }
+}

--- a/src/SteamWebAPI2/Mappings/SteamRemoteStorageProfile.cs
+++ b/src/SteamWebAPI2/Mappings/SteamRemoteStorageProfile.cs
@@ -36,6 +36,8 @@ namespace SteamWebAPI2.Mappings
             CreateMap<UGCFileDetailsResultContainer, UGCFileDetailsModel>().ConvertUsing((src, dest, context) =>
                 context.Mapper.Map<UGCFileDetails, UGCFileDetailsModel>(src.Result)
             );
+            CreateMap<CollectionDetailsResponseContainer, IReadOnlyCollection<CollectionDetail>>().ConvertUsing((src, dest, context) => 
+                context.Mapper.Map<IReadOnlyCollection<CollectionDetail>>(src.Response.CollectionDetails));
         }
     }
 }

--- a/src/SteamWebAPI2/Mappings/SteamWebResponseProfile.cs
+++ b/src/SteamWebAPI2/Mappings/SteamWebResponseProfile.cs
@@ -62,6 +62,7 @@ namespace SteamWebAPI2.Mappings
             CreateSteamWebResponseMap<PublishedFileDetailsResultContainer, IReadOnlyCollection<PublishedFileDetailsModel>>();
             CreateSteamWebResponseMap<PublishedFileDetailsResultContainer, PublishedFileDetailsModel>();
             CreateSteamWebResponseMap<UGCFileDetailsResultContainer, UGCFileDetailsModel>();
+            CreateSteamWebResponseMap<CollectionDetailsResponseContainer, IReadOnlyCollection<CollectionDetail>>();
             CreateSteamWebResponseMap<PlayerSummaryResultContainer, PlayerSummaryModel>();
             CreateSteamWebResponseMap<PlayerSummaryResultContainer, IReadOnlyCollection<PlayerSummaryModel>>();
             CreateSteamWebResponseMap<FriendsListResultContainer, IReadOnlyCollection<FriendModel>>();

--- a/src/SteamWebAPI2/Models/CollectionDetailsResponseContainer.cs
+++ b/src/SteamWebAPI2/Models/CollectionDetailsResponseContainer.cs
@@ -1,30 +1,47 @@
-﻿using System.Collections.Generic;
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 
-namespace Steam.Models
+namespace SteamWebAPI2.Models
 {
     public class CollectionDetailsResponseContainer
     {
+        [JsonProperty("response")]
         public CollectionDetailsResponse Response { get; set; }
     }
 
     public class CollectionDetailsResponse
     {
+        [JsonProperty("result")]
         public uint Result { get; set; }
+
+        [JsonProperty("resultcount")]
         public uint ResultCount { get; set; }
+
+        [JsonProperty("collectiondetails")]
         public IList<CollectionDetail> CollectionDetails { get; set; }
     }
 
     public class CollectionDetail
     {
+        [JsonProperty("publishedfileid")]
         public string PublishedFileId { get; set; }
+
+        [JsonProperty("result")]
         public uint Result { get; set; }
+
+        [JsonProperty("children")]
         public IList<CollectionDetailItem> Children { get; set; }
     }
 
     public class CollectionDetailItem
     {
+        [JsonProperty("publishedfileid")]
         public string PublishedFileId { get; set; }
+
+        [JsonProperty("sortorder")]
         public uint SortOrder { get; set; }
+
+        [JsonProperty("filetype")]
         public uint FileType { get; set; }
     }
 }


### PR DESCRIPTION
Added the `GetCollectionDetails` method to `ISteamRemoteStorage` which accepts either a single `ulong` or `IList<ulong>` via an overload and will return the list of items in that collection.

The `uint FileType` field on `CollectionDetailItem` appears to be some sort of enumeration, however I have only seen `0` returned for mods and `2` for collections, so I am hesitant to give it a concrete implementation.