### PR TITLE
Bugfix/issue 108

### DIFF
--- a/src/Steam.Models/NewsItemModel.cs
+++ b/src/Steam.Models/NewsItemModel.cs
@@ -19,5 +19,7 @@
         public ulong Date { get; set; }
 
         public string Feedname { get; set; }
+
+        public string[] Tags { get; set; }
     }
 }

--- a/src/SteamWebAPI2/Interfaces/ISteamNews.cs
+++ b/src/SteamWebAPI2/Interfaces/ISteamNews.cs
@@ -7,6 +7,6 @@ namespace SteamWebAPI2.Interfaces
 {
     public interface ISteamNews
     {
-        Task<ISteamWebResponse<SteamNewsResultModel>> GetNewsForAppAsync(uint appId, uint? maxLength = null, DateTime? endDate = null, uint? count = null);
+        Task<ISteamWebResponse<SteamNewsResultModel>> GetNewsForAppAsync(uint appId, uint? maxLength = null, DateTime? endDate = null, uint? count = null, string feeds = null, string[] tags = null);
     }
 }

--- a/src/SteamWebAPI2/Interfaces/SteamNews.cs
+++ b/src/SteamWebAPI2/Interfaces/SteamNews.cs
@@ -33,8 +33,10 @@ namespace SteamWebAPI2.Interfaces
         /// <param name="maxLength"></param>
         /// <param name="endDate"></param>
         /// <param name="count"></param>
+        /// <param name="feeds"></param>
+        /// <param name="tags"></param>
         /// <returns></returns>
-        public async Task<ISteamWebResponse<SteamNewsResultModel>> GetNewsForAppAsync(uint appId, uint? maxLength = null, DateTime? endDate = null, uint? count = null)
+        public async Task<ISteamWebResponse<SteamNewsResultModel>> GetNewsForAppAsync(uint appId, uint? maxLength = null, DateTime? endDate = null, uint? count = null, string feeds = null, string[] tags = null)
         {
             ulong? endDateUnixTimeStamp = null;
 
@@ -49,6 +51,8 @@ namespace SteamWebAPI2.Interfaces
             parameters.AddIfHasValue(maxLength, "maxlength");
             parameters.AddIfHasValue(endDateUnixTimeStamp, "enddate");
             parameters.AddIfHasValue(count, "count");
+            parameters.AddIfHasValue(feeds, "feeds");
+            parameters.AddIfHasValue(tags, "tags"); 
 
             var steamWebResponse = await steamWebInterface.GetAsync<SteamNewsResultContainer>("GetNewsForApp", 2, parameters);
 

--- a/src/SteamWebAPI2/Models/SteamNewsResultContainer.cs
+++ b/src/SteamWebAPI2/Models/SteamNewsResultContainer.cs
@@ -31,6 +31,9 @@ namespace SteamWebAPI2.Models
 
         [JsonProperty("feedname")]
         public string Feedname { get; set; }
+
+        [JsonProperty("tags")]
+        public string[] Tags { get; set; }
     }
 
     internal class SteamNewsResult

--- a/src/SteamWebAPI2/Utilities/SteamWebRequest.cs
+++ b/src/SteamWebAPI2/Utilities/SteamWebRequest.cs
@@ -110,6 +110,8 @@ namespace SteamWebAPI2.Utilities
             }
 
             parameters.Insert(0, new SteamWebRequestParameter("key", steamWebApiKey));
+            //parameters.Insert(0, new SteamWebRequestParameter("feeds", "SteamDB")); -- Demonstration of Implementing Feeds Parameter
+            //parameters.Insert(0, new SteamWebRequestParameter("tags", "halloween")); -- Demonstration of Implementing Tags Parameter
 
             HttpResponseMessage httpResponse = null;
 


### PR DESCRIPTION
Added the additional parameters supported by ISteamNews/GetNewsForApp. Made sure to utilize the SteamNewsTests unit test to make sure it didn't break as well as ran the calls with additional parameters (which I left in, uncommented) to make sure that they reduced the number of results and functioned as expected. 