### PR TITLE
Add UnlockTime to PlayerAchievement

### DIFF
--- a/src/Steam.Models/SteamPlayer/PlayerAchievementModel.cs
+++ b/src/Steam.Models/SteamPlayer/PlayerAchievementModel.cs
@@ -1,10 +1,14 @@
-﻿namespace Steam.Models.SteamPlayer
+﻿using System;
+
+namespace Steam.Models.SteamPlayer
 {
     public class PlayerAchievementModel
     {
         public string APIName { get; set; }
 
         public uint Achieved { get; set; }
+
+        public DateTime UnlockTime { get; set; }
 
         public string Name { get; set; }
 

--- a/src/SteamWebAPI2/Mappings/SteamUserStatsProfile.cs
+++ b/src/SteamWebAPI2/Mappings/SteamUserStatsProfile.cs
@@ -7,6 +7,7 @@ using Steam.Models.SteamPlayer;
 using SteamWebAPI2.Models;
 using SteamWebAPI2.Models.SteamCommunity;
 using SteamWebAPI2.Models.SteamPlayer;
+using SteamWebAPI2.Utilities;
 
 namespace SteamWebAPI2.Mappings
 {
@@ -29,7 +30,8 @@ namespace SteamWebAPI2.Mappings
                 src.Result != null ? src.Result.PlayerCount : default(uint)
             );
 
-            CreateMap<PlayerAchievement, PlayerAchievementModel>();
+            CreateMap<PlayerAchievement, PlayerAchievementModel>()
+                .ForMember(dest => dest.UnlockTime, opts => opts.MapFrom(source => source.UnlockTime.ToDateTime()));
             CreateMap<PlayerAchievementResult, PlayerAchievementResultModel>();
             CreateMap<PlayerAchievementResultContainer, PlayerAchievementResultModel>().ConvertUsing((src, dest, context) =>
                 context.Mapper.Map<PlayerAchievementResult, PlayerAchievementResultModel>(src.Result)

--- a/src/SteamWebAPI2/Models/SteamPlayer/PlayerAchievementResultContainer.cs
+++ b/src/SteamWebAPI2/Models/SteamPlayer/PlayerAchievementResultContainer.cs
@@ -11,6 +11,9 @@ namespace SteamWebAPI2.Models.SteamPlayer
         [JsonProperty("achieved")]
         public uint Achieved { get; set; }
 
+        [JsonProperty("unlocktime")]
+        public ulong UnlockTime { get; set; }
+
         public string Name { get; set; }
         public string Description { get; set; }
     }


### PR DESCRIPTION
The `unlocktime` field was missing from ISteamUserStats/GetPlayerAchievements, so I added it.