### PR TITLE
support for custom SteamWebApiBaseUrl

### DIFF
--- a/src/SteamWebAPI2/Utilities/SteamWebInterfaceFactory.cs
+++ b/src/SteamWebAPI2/Utilities/SteamWebInterfaceFactory.cs
@@ -44,6 +44,11 @@ namespace SteamWebAPI2.Utilities
 
             this.steamWebApiKey = options.Value.SteamWebApiKey;
 
+            if (!string.IsNullOrWhiteSpace(options.Value.SteamWebApiBaseUrl))
+            {
+                this.steamWebApiBaseUrl = options.Value.SteamWebApiBaseUrl;
+            }
+
             var mapperConfig = new MapperConfiguration(config =>
             {
                 config.AddProfile<SteamWebResponseProfile>();

--- a/src/SteamWebAPI2/Utilities/SteamWebInterfaceFactoryOptions.cs
+++ b/src/SteamWebAPI2/Utilities/SteamWebInterfaceFactoryOptions.cs
@@ -3,5 +3,6 @@ namespace SteamWebAPI2.Utilities
     public class SteamWebInterfaceFactoryOptions
     {
         public string SteamWebApiKey { get; set; }
+        public string SteamWebApiBaseUrl { get; set; }
     }
 }


### PR DESCRIPTION
Useful for people who are steam publishers. As mentioned [here](https://partner.steamgames.com/doc/webapi_overview) it's possible to access web api through https://partner.steam-api.com if you're a steam publisher. That host is unavailable less often than the public one.