### PR TITLE
Target netstandard2.1 and bump AutoMapper version to prevent version conflicts

### DIFF
--- a/src/Steam.Models/Steam.Models.csproj
+++ b/src/Steam.Models/Steam.Models.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/Steam.UnitTests/Steam.UnitTests.csproj
+++ b/src/Steam.UnitTests/Steam.UnitTests.csproj
@@ -6,7 +6,7 @@
     <UserSecretsId>46a53f4e-b4d4-4fad-b7c9-b777001cfe42</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="automapper" Version="10.1.1" />
+    <PackageReference Include="automapper" Version="11.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />

--- a/src/SteamWebAPI2/SteamWebAPI2.csproj
+++ b/src/SteamWebAPI2/SteamWebAPI2.csproj
@@ -15,7 +15,7 @@
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="automapper" Version="10.1.1" />
+    <PackageReference Include="automapper" Version="11.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
     <PackageReference Include="newtonsoft.json" Version="12.0.3" />

--- a/src/SteamWebAPI2/SteamWebAPI2.csproj
+++ b/src/SteamWebAPI2/SteamWebAPI2.csproj
@@ -8,7 +8,7 @@
     <PackageId>SteamWebAPI2</PackageId>
     <PackageProjectUrl>https://github.com/babelshift/SteamWebAPI2</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- https://github.com/nuget/home/issues/3891 -->


### PR DESCRIPTION
All unit tests passing before this change still pass.